### PR TITLE
Set a map center and zoom level per layer (#159)

### DIFF
--- a/app/controllers/layers_controller.rb
+++ b/app/controllers/layers_controller.rb
@@ -138,6 +138,6 @@ class LayersController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def layer_params
-    params.require(:layer).permit(:title, :subtitle, :text, :credits, :published, :public_submission, :map_id, :color, :image)
+    params.require(:layer).permit(:title, :subtitle, :text, :credits, :published, :public_submission, :map_id, :color, :mapcenter_lat, :mapcenter_lon, :zoom, :image)
   end
 end

--- a/app/views/layers/_form.html.haml
+++ b/app/views/layers/_form.html.haml
@@ -30,21 +30,22 @@
               %span.hint.text-left Enable public submissions
             - if @layer.public_submission
               - if @layer.submission_config
-                = link_to edit_submission_config_path(@layer.submission_config.id), :class=>"button" do
+                = link_to edit_submission_config_path(@layer.submission_config.id), :class=>"button small" do
                   %i.fi-pencil.fi-24
                   Edit configuration
-                %br
-                Submission forms:
-                %br
-                - @layer.submission_config.locales.each do |language|
-                  - klass = 'button secondary'
-                  = link_to new_submission_path(layer_id: @layer.id, locale: language.to_s), class: "#{klass}", target: '_blank' do
-                    %i.fi-web.fi-24
-                    - title = @layer.submission_config.title_intro(locale: language)
-                    - if title.nil?
-                      %i Missing title
-                    - else
-                      = title
+                - if @layer.submission_config.locales.count > 0
+                  %br
+                  Submission forms:
+                  %br
+                  - @layer.submission_config.locales.each do |language|
+                    - klass = 'button secondary'
+                    = link_to new_submission_path(layer_id: @layer.id, locale: language.to_s), class: "#{klass}", target: '_blank' do
+                      %i.fi-web.fi-24
+                      - title = @layer.submission_config.title_intro(locale: language)
+                      - if title.nil?
+                        %i Missing title
+                      - else
+                        = title
               - else
                 = link_to new_submission_config_path(layer_id: @layer.id), :class=>"button" do
                   %i.fi-pencil.fi-24
@@ -72,6 +73,17 @@
                       %svg{height:24,width:24,version:"1.1",xmlns:"http://www.w3.org/2000/svg"}
                         %circle{cx:"12",cy:"12",r:"12",fill:"#{c}"}
 
+        %hr
+        %div.compact
+          %label Mapcenter
+          %span.hint.text-left Set these values if you want a different map focus then the automatic calculation of alle places would give
+          .grid-x.grid-padding-x
+            .medium-5.cell
+              = f.input :mapcenter_lat, label: "Latitude", input_html: { placeholder: '53.0000'}
+            .medium-5.cell
+              = f.input :mapcenter_lon, label: "Longitude", input_html: { placeholder: '10.0000'}
+            .medium-2.cell
+              = f.input :zoom, label: "Zoom (1-18)", input_html: { placeholder: '12'}
 
 
         %hr

--- a/app/views/layers/_form.html.haml
+++ b/app/views/layers/_form.html.haml
@@ -76,7 +76,7 @@
         %hr
         %div.compact
           %label Mapcenter
-          %span.hint.text-left Set these values if you want a different map focus then the automatic calculation of alle places would give
+          %span.hint.text-left Set these values if you want a different map focus then the automatic calculation of all places would give
           .grid-x.grid-padding-x
             .medium-5.cell
               = f.input :mapcenter_lat, label: "Latitude", input_html: { placeholder: '53.0000'}

--- a/app/views/layers/_layer.json.jbuilder
+++ b/app/views/layers/_layer.json.jbuilder
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-json.extract! layer, :id, :title, :subtitle, :text, :credits, :image_link, :published, :map_id, :color, :created_at, :updated_at
+json.extract! layer, :id, :title, :subtitle, :text, :credits, :image_link, :published, :map_id, :color, :mapcenter_lat, :mapcenter_lon, :zoom, :created_at, :updated_at
 json.url map_layer_url(layer, format: :json)
 json.iconset layer.map.iconset, :title, :icon_anchor, :icon_size, :popup_anchor, :class_name if layer.map.iconset
 json.places layer.places do |place|

--- a/app/views/public/layers/show.json.jbuilder
+++ b/app/views/public/layers/show.json.jbuilder
@@ -3,7 +3,7 @@
 json.layer do
   next unless @layer.published
 
-  json.call(@layer, :id, :title, :subtitle, :text, :credits, :image_link, :color, :mapcenter_lat, :mapcenter_lon, :zoom,:created_at, :updated_at, :published)
+  json.call(@layer, :id, :title, :subtitle, :text, :credits, :image_link, :color, :mapcenter_lat, :mapcenter_lon, :zoom, :created_at, :updated_at, :published)
   json.places do
     json.array! @layer.places.published do |place|
       next unless place.published

--- a/app/views/public/layers/show.json.jbuilder
+++ b/app/views/public/layers/show.json.jbuilder
@@ -3,7 +3,7 @@
 json.layer do
   next unless @layer.published
 
-  json.call(@layer, :id, :title, :subtitle, :text, :credits, :image_link, :color, :created_at, :updated_at, :published)
+  json.call(@layer, :id, :title, :subtitle, :text, :credits, :image_link, :color, :mapcenter_lat, :mapcenter_lon, :zoom,:created_at, :updated_at, :published)
   json.places do
     json.array! @layer.places.published do |place|
       next unless place.published

--- a/db/migrate/20211215112115_add_map_settings_to_layer.rb
+++ b/db/migrate/20211215112115_add_map_settings_to_layer.rb
@@ -1,0 +1,7 @@
+class AddMapSettingsToLayer < ActiveRecord::Migration[5.2]
+  def change
+    add_column :layers, :mapcenter_lat, :string
+    add_column :layers, :mapcenter_lon, :string
+    add_column :layers, :zoom, :integer, default: 12
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_03_131943) do
+ActiveRecord::Schema.define(version: 2021_12_15_112115) do
 
-  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
     t.integer "record_id", null: false
@@ -22,7 +22,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
   end
 
-  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "active_storage_blobs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "key", null: false
     t.string "filename", null: false
     t.string "content_type"
@@ -33,17 +33,18 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
-  create_table "annotations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "annotations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "text"
     t.bigint "place_id"
+    t.bigint "person_id"
     t.boolean "published", default: false
     t.integer "sorting"
     t.text "source"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.integer "person_id"
-    t.index ["place_id"], name: "index_annotations_on_place_id"
+    t.index ["person_id"], name: "fk_rails_adeffa1c70"
+    t.index ["place_id"], name: "fk_rails_51dbcfe977"
   end
 
   create_table "friendly_id_slugs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -63,7 +64,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "icons", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "icons", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.integer "iconset_id"
     t.datetime "created_at", null: false
@@ -71,7 +72,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["iconset_id"], name: "index_icons_on_iconset_id"
   end
 
-  create_table "iconsets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "iconsets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "text"
     t.datetime "created_at", null: false
@@ -82,7 +83,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.string "class_name"
   end
 
-  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.string "licence"
     t.text "source"
@@ -97,15 +98,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["place_id"], name: "index_images_on_place_id"
   end
 
-  create_table "jwt_denylists", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.string "jti"
-    t.datetime "exp"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["jti"], name: "index_jwt_denylists_on_jti"
-  end
-
-  create_table "layers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "layers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.string "subtitle"
     t.boolean "published"
@@ -117,11 +110,14 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.boolean "public_submission"
     t.string "slug"
     t.text "credits"
+    t.string "mapcenter_lat"
+    t.string "mapcenter_lon"
+    t.integer "zoom", default: 12
     t.index ["map_id"], name: "index_layers_on_map_id"
     t.index ["slug"], name: "index_layers_on_slug", unique: true
   end
 
-  create_table "maps", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "maps", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.string "subtitle"
     t.boolean "published"
@@ -143,7 +139,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["slug"], name: "index_maps_on_slug", unique: true
   end
 
-  create_table "mobility_string_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "mobility_string_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "locale", null: false
     t.string "key", null: false
     t.string "value"
@@ -156,7 +152,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["translatable_type", "key", "value", "locale"], name: "index_mobility_string_translations_on_query_keys"
   end
 
-  create_table "mobility_text_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "mobility_text_translations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "locale", null: false
     t.string "key", null: false
     t.text "value"
@@ -168,14 +164,14 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["translatable_id", "translatable_type", "locale", "key"], name: "index_mobility_text_translations_on_keys", unique: true
   end
 
-  create_table "people", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "people", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.text "info"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "places", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "places", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.text "teaser"
     t.text "text"
@@ -201,7 +197,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["layer_id"], name: "index_places_on_layer_id"
   end
 
-  create_table "relations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "relations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "relation_from_id"
     t.integer "relation_to_id"
     t.string "rtype"
@@ -209,7 +205,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "submission_configs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "submission_configs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title_intro"
     t.string "subtitle_intro"
     t.text "intro"
@@ -225,7 +221,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["layer_id"], name: "index_submission_configs_on_layer_id"
   end
 
-  create_table "submissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "submissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name"
     t.string "email"
     t.boolean "rights"
@@ -238,7 +234,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["place_id"], name: "index_submissions_on_place_id"
   end
 
-  create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "taggings", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "tag_id"
     t.string "taggable_type"
     t.integer "taggable_id"
@@ -257,7 +253,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["tagger_id"], name: "index_taggings_on_tagger_id"
   end
 
-  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "tags", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", collation: "utf8_bin"
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -265,7 +261,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["name"], name: "index_tags_on_name", unique: true
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -277,15 +273,15 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.string "current_sign_in_ip"
     t.string "last_sign_in_ip"
     t.string "role", default: "user"
-    t.bigint "group_id"
-    t.datetime "created_at", default: "2021-11-06 17:42:00", null: false
-    t.datetime "updated_at", default: "2021-11-06 17:42:00", null: false
+    t.integer "group_id"
+    t.datetime "created_at", default: "2021-06-28 17:11:21", null: false
+    t.datetime "updated_at", default: "2021-06-28 17:11:21", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["group_id"], name: "index_users_on_group_id"
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "videos", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "videos", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "title"
     t.string "licence"
     t.text "source"
@@ -300,6 +296,7 @@ ActiveRecord::Schema.define(version: 2021_12_03_131943) do
     t.index ["place_id"], name: "index_videos_on_place_id"
   end
 
+  add_foreign_key "annotations", "people"
   add_foreign_key "annotations", "places"
   add_foreign_key "submission_configs", "layers"
   add_foreign_key "submissions", "places"

--- a/spec/controllers/public/maps_controller_spec.rb
+++ b/spec/controllers/public/maps_controller_spec.rb
@@ -59,7 +59,6 @@ RSpec.describe Public::MapsController, type: :controller do
         layer = FactoryBot.create(:layer, map_id: map.id, published: true)
         place = FactoryBot.create(:place, layer_id: layer.id, published: true)
         get :show, params: { id: map.friendly_id, format: 'json' }, session: valid_session
-        # puts response.body
         expect(response).to match_response_schema('map', 'json')
       end
 

--- a/spec/factories/layers.rb
+++ b/spec/factories/layers.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     text { 'MyString' }
     credits { 'MyString' }
     published { false }
+    color { '#cc0000' }
+    mapcenter_lat { '0.1' }
+    mapcenter_lon { '10' }
+    zoom { 12 }
     map
     submission_config { false }
     trait :invalid do

--- a/spec/helpers/places_helper_spec.rb
+++ b/spec/helpers/places_helper_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe PlacesHelper, type: :helper do
     it 'it returns an polymorphic audio link' do
       p = Place.new
       p.audio.attach(io: File.open(Rails.root.join('spec', 'support', 'files', 'test.mp3')), filename: 'attachment.mp3', content_type: 'audio/mpeg')
-      expect(helper.audio_link(p.audio)).to eq("<audio autoplay=\"autoplay\" controls=\"controls\" src=\"http://test.host#{rails_blob_path(p.audio)}\"></audio>")
+      expect(helper.audio_link(p.audio)).to eq("<audio controls=\"controls\" src=\"http://test.host#{rails_blob_path(p.audio)}\"></audio>")
     end
   end
 end

--- a/spec/support/api/layer.json
+++ b/spec/support/api/layer.json
@@ -53,6 +53,56 @@
             ],
             "pattern": "^(.*)$"
           },
+          "image_link": {
+            "$id": "#/properties/map/properties/layer/items/properties/image_link",
+            "type": "string",
+            "title": "The Image_link Schema",
+            "default": "",
+            "examples": [
+              ""
+            ],
+            "pattern": "^(.*)$"
+          },
+          "color": {
+            "$id": "#/properties/map/properties/layer/items/properties/color",
+            "type": "string",
+            "title": "The Color Schema",
+            "default": "",
+            "examples": [
+              ""
+            ],
+            "pattern": "^(.*)$"
+          },
+          "mapcenter_lat": {
+            "$id": "#/properties/map/properties/layer/items/properties/mapcenter_lat",
+            "type": "string",
+            "title": "The Mapcenter_lat Schema",
+            "default": "",
+            "examples": [
+              ""
+            ],
+            "pattern": "^(.*)$"
+          },
+          "mapcenter_lon": {
+            "$id": "#/properties/map/properties/layer/items/properties/mapcenter_lon",
+            "type": "string",
+            "title": "The Mapcenter_lon Schema",
+            "default": "",
+            "examples": [
+              ""
+            ],
+            "pattern": "^(.*)$"
+          },
+          "zoom": {
+            "$id": "#/properties/map/properties/layer/items/properties/zoom",
+            "type": "string",
+            "title": "The Zoom Schema",
+            "default": "",
+            "examples": [
+              ""
+            ],
+            "pattern": "^(.*)$"
+          },
           "created_at": {
             "$id": "#/properties/map/properties/layer/items/properties/created_at",
             "type": "string",

--- a/spec/support/api/map.json
+++ b/spec/support/api/map.json
@@ -1,709 +1,779 @@
 {
-  "definitions": {},
-  "type": "object",
-  "title": "The Root Schema",
-  "required": [
-    "map"
-  ],
-  "properties": {
-    "map": {
-      "$id": "#/properties/map",
-      "type": "object",
-      "title": "The Map Schema",
-      "required": [
-        "id",
-        "title",
-        "subtitle",
-        "text",
-        "credits",
-        "image_link",
-        "created_at",
-        "updated_at",
-        "published",
-        "owner",
-        "layer"
-      ],
-      "properties": {
-        "id": {
-          "$id": "#/properties/map/properties/id",
-          "type": "integer",
-          "title": "The Id Schema",
-          "default": 0,
-          "examples": [
-            2
-          ]
-        },
-        "title": {
-          "$id": "#/properties/map/properties/title",
-          "type": "string",
-          "title": "The Title Schema",
-          "default": "",
-          "examples": [
-            "Treffen Total 2018"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "subtitle": {
-          "$id": "#/properties/map/properties/subtitle",
-          "type": "string",
-          "title": "The Subtitle Schema",
-          "default": "",
-          "examples": [
-            "Events in public space"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "text": {
-          "$id": "#/properties/map/properties/text",
-          "type": "string",
-          "title": "The Text Schema",
-          "default": "",
-          "examples": [
-            "Some text in 1 or more phrases"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "credits": {
-          "$id": "#/properties/map/properties/credits",
-          "type": "string",
-          "title": "The Credits Schema",
-          "default": "",
-          "examples": [
-            "Some credits"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "image_link": {
-          "$id": "#/properties/map/properties/image_link",
-          "pattern": "^(.*)$",
-          "type": "null",
-          "title": "The Imagelink Schema",
-          "default": null,
-          "examples": [
-            null
-          ]
-        },
-        "created_at": {
-          "$id": "#/properties/map/properties/created_at",
-          "type": "string",
-          "title": "The Created_at Schema",
-          "default": "",
-          "examples": [
-            "2018-05-08T12:01:56.192Z"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "updated_at": {
-          "$id": "#/properties/map/properties/updated_at",
-          "type": "string",
-          "title": "The Updated_at Schema",
-          "default": "",
-          "examples": [
-            "2018-06-09T17:45:05.990Z"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "published": {
-          "$id": "#/properties/map/properties/published",
-          "type": "boolean",
-          "title": "The Published Schema",
-          "default": false,
-          "examples": [
-            true
-          ]
-        },
-        "owner": {
-          "$id": "#/properties/map/properties/owner",
-          "type": "string",
-          "title": "The Owner Schema",
-          "default": "",
-          "examples": [
-            "Treffen Total"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "layer": {
-          "$id": "#/properties/map/properties/layer",
-          "type": "array",
-          "title": "The Layer Schema",
-          "items": {
-            "$id": "#/properties/map/properties/layer/items",
-            "type": "object",
-            "title": "The Items Schema",
-            "required": [
-              "id",
-              "title",
-              "text",
-              "created_at",
-              "updated_at",
-              "published",
-              "places"
-            ],
-            "properties": {
-              "id": {
-                "$id": "#/properties/map/properties/layer/items/properties/id",
-                "type": "integer",
-                "title": "The Id Schema",
-                "default": 0,
-                "examples": [
-                  3
-                ]
-              },
-              "title": {
-                "$id": "#/properties/map/properties/layer/items/properties/title",
-                "type": "string",
-                "title": "The Title Schema",
-                "default": "",
-                "examples": [
+   "definitions":{
+
+   },
+   "type":"object",
+   "title":"The Root Schema",
+   "required":[
+      "map"
+   ],
+   "properties":{
+      "map":{
+         "$id":"#/properties/map",
+         "type":"object",
+         "title":"The Map Schema",
+         "required":[
+            "id",
+            "title",
+            "subtitle",
+            "text",
+            "credits",
+            "image_link",
+            "created_at",
+            "updated_at",
+            "published",
+            "owner",
+            "layer"
+         ],
+         "properties":{
+            "id":{
+               "$id":"#/properties/map/properties/id",
+               "type":"integer",
+               "title":"The Id Schema",
+               "default":0,
+               "examples":[
+                  2
+               ]
+            },
+            "title":{
+               "$id":"#/properties/map/properties/title",
+               "type":"string",
+               "title":"The Title Schema",
+               "default":"",
+               "examples":[
+                  "Treffen Total 2018"
+               ],
+               "pattern":"^(.*)$"
+            },
+            "subtitle":{
+               "$id":"#/properties/map/properties/subtitle",
+               "type":"string",
+               "title":"The Subtitle Schema",
+               "default":"",
+               "examples":[
                   "Events in public space"
-                ],
-                "pattern": "^(.*)$"
-              },
-              "subtitle": {
-                "$id": "#/properties/map/properties/layer/items/properties/subtitle",
-                "type": "string",
-                "title": "The Subtitle Schema",
-                "default": "",
-                "examples": [
-                  "Events in public space"
-                ],
-                "pattern": "^(.*)$"
-              },
-              "text": {
-                "$id": "#/properties/map/properties/layer/items/properties/text",
-                "type": "string",
-                "title": "The Text Schema",
-                "default": "Some tex in 1 or more phrases",
-                "examples": [
-                  ""
-                ],
-                "pattern": "^(.*)$"
-              },
-              "credits": {
-                "$id": "#/properties/map/properties/layer/items/properties/credits",
-                "type": "string",
-                "title": "The Credits Schema",
-                "default": "",
-                "examples": [
+               ],
+               "pattern":"^(.*)$"
+            },
+            "text":{
+               "$id":"#/properties/map/properties/text",
+               "type":"string",
+               "title":"The Text Schema",
+               "default":"",
+               "examples":[
+                  "Some text in 1 or more phrases"
+               ],
+               "pattern":"^(.*)$"
+            },
+            "credits":{
+               "$id":"#/properties/map/properties/credits",
+               "type":"string",
+               "title":"The Credits Schema",
+               "default":"",
+               "examples":[
                   "Some credits"
-                ],
-                "pattern": "^(.*)$"
-              },
-              "image_link": {
-                "$id": "#/properties/map/properties/layer/items/properties/image_link",
-                "pattern": "^(.*)$",
-                "type": "null",
-                "title": "The Imagelink Schema",
-                "default": null,
-                "examples": [
+               ],
+               "pattern":"^(.*)$"
+            },
+            "image_link":{
+               "$id":"#/properties/map/properties/image_link",
+               "pattern":"^(.*)$",
+               "type":"null",
+               "title":"The Imagelink Schema",
+               "default":null,
+               "examples":[
                   null
-                ]
-              },
-              "created_at": {
-                "$id": "#/properties/map/properties/layer/items/properties/created_at",
-                "type": "string",
-                "title": "The Created_at Schema",
-                "default": "",
-                "examples": [
-                  "2018-05-08T12:02:18.823Z"
-                ],
-                "pattern": "^(.*)$"
-              },
-              "updated_at": {
-                "$id": "#/properties/map/properties/layer/items/properties/updated_at",
-                "type": "string",
-                "title": "The Updated_at Schema",
-                "default": "",
-                "examples": [
-                  "2018-05-08T12:02:18.823Z"
-                ],
-                "pattern": "^(.*)$"
-              },
-              "published": {
-                "$id": "#/properties/map/properties/layer/items/properties/published",
-                "type": "boolean",
-                "title": "The Published Schema",
-                "default": false,
-                "examples": [
+               ]
+            },
+            "created_at":{
+               "$id":"#/properties/map/properties/created_at",
+               "type":"string",
+               "title":"The Created_at Schema",
+               "default":"",
+               "examples":[
+                  "2018-05-08T12:01:56.192Z"
+               ],
+               "pattern":"^(.*)$"
+            },
+            "updated_at":{
+               "$id":"#/properties/map/properties/updated_at",
+               "type":"string",
+               "title":"The Updated_at Schema",
+               "default":"",
+               "examples":[
+                  "2018-06-09T17:45:05.990Z"
+               ],
+               "pattern":"^(.*)$"
+            },
+            "published":{
+               "$id":"#/properties/map/properties/published",
+               "type":"boolean",
+               "title":"The Published Schema",
+               "default":false,
+               "examples":[
                   true
-                ]
-              },
-              "places": {
-                "$id": "#/properties/map/properties/layer/items/properties/places",
-                "type": "array",
-                "title": "The Places Schema",
-                "items": {
-                  "$id": "#/properties/map/properties/layer/items/properties/places/items",
-                  "type": "object",
-                  "title": "The Items Schema",
-                  "required": [
-                    "id",
-                    "title",
-                    "teaser",
-                    "link",
-                    "imagelink",
-                    "imagelink2",
-                    "audiolink",
-                    "published",
-                    "startdate",
-                    "enddate",
-                    "lat",
-                    "lon",
-                    "location",
-                    "address",
-                    "zip",
-                    "city",
-                    "country",
-                    "featured",
-                    "layer_id"
+               ]
+            },
+            "owner":{
+               "$id":"#/properties/map/properties/owner",
+               "type":"string",
+               "title":"The Owner Schema",
+               "default":"",
+               "examples":[
+                  "Treffen Total"
+               ],
+               "pattern":"^(.*)$"
+            },
+            "layer":{
+               "$id":"#/properties/map/properties/layer",
+               "type":"array",
+               "title":"The Layer Schema",
+               "items":{
+                  "$id":"#/properties/map/properties/layer/items",
+                  "type":"object",
+                  "title":"The Items Schema",
+                  "required":[
+                     "id",
+                     "title",
+                     "created_at",
+                     "updated_at",
+                     "published",
+                     "places"
                   ],
-                  "properties": {
-                    "id": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/id",
-                      "type": "integer",
-                      "title": "The Id Schema",
-                      "default": 0,
-                      "examples": [
-                        4
-                      ]
-                    },
-                    "title": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/title",
-                      "type": "string",
-                      "title": "The Title Schema",
-                      "default": "",
-                      "examples": [
-                        "Session am Deich"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "teaser": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/teaser",
-                      "type": "string",
-                      "title": "The Teaser Schema",
-                      "default": "",
-                      "examples": [
-                        ""
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "text": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/text",
-                      "type": "string",
-                      "title": "The Text Schema",
-                      "default": "",
-                      "examples": [
-                        ""
-                      ]
-                    },
-                    "link": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/link",
-                      "type": "string",
-                      "title": "The Link Schema",
-                      "default": "",
-                      "examples": [
-                        ""
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "imagelink": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/imagelink",
-                      "type": "null",
-                      "title": "The Imagelink Schema",
-                      "default": null,
-                      "examples": [
-                        null
-                      ]
-                    },
-                    "imagelink2": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/imagelink2",
-                      "type": "null",
-                      "title": "The Imagelink Schema",
-                      "default": null,
-                      "examples": [
-                        null
-                      ]
-                    },
-                    "audiolink": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/audiolink",
-                      "type": "null",
-                      "title": "The Audiolink Schema",
-                      "default": null,
-                      "examples": [
-                        null
-                      ]
-                    },
-                    "published": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/published",
-                      "type": "boolean",
-                      "title": "The Published Schema",
-                      "default": false,
-                      "examples": [
-                        true
-                      ]
-                    },
-                    "startdate": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/startdate",
-                      "type": "string",
-                      "title": "The Startdate Schema",
-                      "default": "",
-                      "examples": [
-                        "2018-05-18T17:57:00.000Z"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "enddate": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/enddate",
-                      "type": "string",
-                      "title": "The Enddate Schema",
-                      "default": "",
-                      "examples": [
-                        "2018-05-18T17:57:00.000Z"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "lat": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/lat",
-                      "type": "string",
-                      "title": "The Lat Schema",
-                      "default": "",
-                      "examples": [
-                        "53.532969"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "lon": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/lon",
-                      "type": "string",
-                      "title": "The Lon Schema",
-                      "default": "",
-                      "examples": [
-                        "10.0367449"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "location": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/location",
-                      "type": "string",
-                      "title": "The Location Schema",
-                      "default": "",
-                      "examples": [
-                        "Billwerder Neuer Deich"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "address": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/address",
-                      "type": "string",
-                      "title": "The Address Schema",
-                      "default": "",
-                      "examples": [
-                        "Billwerder Neuer Deich undefined"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "zip": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/zip",
-                      "type": "string",
-                      "title": "The Zip Schema",
-                      "default": "",
-                      "examples": [
-                        "20539"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "city": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/city",
-                      "type": "string",
-                      "title": "The City Schema",
-                      "default": "",
-                      "examples": [
-                        "Hamburg"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "country": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/country",
-                      "type": "string",
-                      "title": "The Country Schema",
-                      "default": "",
-                      "examples": [
-                        ""
-                      ]
-                    },
-                    "featured": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/featured",
-                      "type": "null",
-                      "title": "The Featured Schema",
-                      "default": false,
-                      "examples": [
-                        true
-                      ]
-                    },
-                    "layer_id": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/layer_id",
-                      "type": "integer",
-                      "title": "The Layer_id Schema",
-                      "default": 0,
-                      "examples": [
-                        3
-                      ]
-                    },
-                    "icon_link": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/icon_link",
-                      "type": "null",
-                      "title": "The Icon Link Schema",
-                      "default": "",
-                      "examples": [
-                        "http://test.domain/path/to/the/icon/file.png"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "icon_class": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/icon_class",
-                      "type": "null",
-                      "title": "The Icon Class Schema",
-                      "default": "",
-                      "examples": [
-                        "marker-klass"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "icon_name": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/icon_name",
-                      "type": "null",
-                      "title": "The Icon Name Schema",
-                      "default": "",
-                      "examples": [
-                        "Name"
-                      ],
-                      "pattern": "^(.*)$"
-                    },
-                    "images": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places/properties/images",
-                      "type": "array",
-                      "title": "The Images Schema",
-                      "items": {
-                        "$id": "#/properties/map/properties/layer/items/properties/places/items/images/otem",
-                        "type": "object",
-                        "title": "The Items Schema",
-                        "required": [
-                          "id",
-                          "title",
-                          "source",
-                          "creator",
-                          "alt",
-                          "sorting",
-                          "image_linktag",
-                          "image_url"
+                  "properties":{
+                     "id":{
+                        "$id":"#/properties/map/properties/layer/items/properties/id",
+                        "type":"integer",
+                        "title":"The Id Schema",
+                        "default":0,
+                        "examples":[
+                           3
+                        ]
+                     },
+                     "title":{
+                        "$id":"#/properties/map/properties/layer/items/properties/title",
+                        "type":"string",
+                        "title":"The Title Schema",
+                        "default":"",
+                        "examples":[
+                           "Events in public space"
                         ],
-                        "properties": {
-                          "id": {
-                            "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/id",
-                            "type": "integer",
-                            "title": "The Id Schema",
-                            "default": 0,
-                            "examples": [
-                              4
-                            ]
-                          },
-                          "title": {
-                            "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/title",
-                            "type": "string",
-                            "title": "The Title Schema",
-                            "default": "",
-                            "examples": [
-                              "Session am Deich"
-                            ],
-                            "pattern": "^(.*)$"
-                          },
-                          "source": {
-                            "$id": "#/properties/source/properties/layer/items/properties/places/items/properties/title",
-                            "type": "string",
-                            "title": "The Source Schema",
-                            "default": "",
-                            "examples": [
-                              "The projects archive"
-                            ],
-                            "pattern": "^(.*)$"
-                          },
-                          "creator": {
-                            "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/creator",
-                            "type": "string",
-                            "title": "The Creator Schema",
-                            "default": "",
-                            "examples": [
-                              "Photographer"
-                            ],
-                            "pattern": "^(.*)$"
-                          },
-                          "alt": {
-                            "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/alt",
-                            "type": "string",
-                            "title": "The Alt Schema",
-                            "default": "",
-                            "examples": [
-                              "Some people at the session"
-                            ],
-                            "pattern": "^(.*)$"
-                          },
-                          "sorting": {
-                            "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/sorting",
-                            "type": "string",
-                            "title": "The Sorting Schema",
-                            "default": "",
-                            "examples": [
-                              "5"
-                            ],
-                            "pattern": "^(.*)$"
-                          },
-                          "image_linktag": {
-                            "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/image_linktag",
-                            "type": "string",
-                            "title": "The Image Linktag Schema",
-                            "default": "",
-                            "examples": [
-                              ""
-                            ],
-                            "pattern": "^(.*)$"
-                          },
-                          "image_url": {
-                            "$id": "#/properties/map/properties/layer/items/properties/places/items/properties/image_url",
-                            "type": "null",
-                            "title": "The Image URL Schema",
-                            "default": null,
-                            "examples": [
-                              null
-                            ]
-                          }
+                        "pattern":"^(.*)$"
+                     },
+                     "subtitle":{
+                        "$id":"#/properties/map/properties/layer/items/properties/subtitle",
+                        "type":"string",
+                        "title":"The Subtitle Schema",
+                        "default":"",
+                        "examples":[
+                           "Events in public space"
+                        ],
+                        "pattern":"^(.*)$"
+                     },
+                     "text":{
+                        "$id":"#/properties/map/properties/layer/items/properties/text",
+                        "type":"string",
+                        "title":"The Text Schema",
+                        "default":"Some tex in 1 or more phrases",
+                        "examples":[
+                           ""
+                        ],
+                        "pattern":"^(.*)$"
+                     },
+                     "credits":{
+                        "$id":"#/properties/map/properties/layer/items/properties/credits",
+                        "type":"string",
+                        "title":"The Credits Schema",
+                        "default":"",
+                        "examples":[
+                           "Some credits"
+                        ],
+                        "pattern":"^(.*)$"
+                     },
+                     "image_link":{
+                        "$id":"#/properties/map/properties/layer/items/properties/image_link",
+                        "pattern":"^(.*)$",
+                        "type":"null",
+                        "title":"The Imagelink Schema",
+                        "default":null,
+                        "examples":[
+                           null
+                        ]
+                     },
+                    "color": {
+                      "$id": "#/properties/map/properties/layer/items/properties/color",
+                      "type": "string",
+                      "title": "The Color Schema",
+                      "default": "",
+                      "examples": [
+                        ""
+                      ],
+                      "pattern": "^(.*)$"
+                    },
+                     "created_at":{
+                        "$id":"#/properties/map/properties/layer/items/properties/created_at",
+                        "type":"string",
+                        "title":"The Created_at Schema",
+                        "default":"",
+                        "examples":[
+                           "2018-05-08T12:02:18.823Z"
+                        ],
+                        "pattern":"^(.*)$"
+                     },
+                     "updated_at":{
+                        "$id":"#/properties/map/properties/layer/items/properties/updated_at",
+                        "type":"string",
+                        "title":"The Updated_at Schema",
+                        "default":"",
+                        "examples":[
+                           "2018-05-08T12:02:18.823Z"
+                        ],
+                        "pattern":"^(.*)$"
+                     },
+                     "published":{
+                        "$id":"#/properties/map/properties/layer/items/properties/published",
+                        "type":"boolean",
+                        "title":"The Published Schema",
+                        "default":false,
+                        "examples":[
+                           true
+                        ]
+                     },
+                     "places":{
+                        "$id":"#/properties/map/properties/layer/items/properties/places",
+                        "type":"array",
+                        "title":"The Places Schema",
+                        "items":{
+                           "$id":"#/properties/map/properties/layer/items/properties/places/items",
+                           "type":"object",
+                           "title":"The Items Schema",
+                           "required":[
+                              "id",
+                              "title",
+                              "teaser",
+                              "link",
+                              "imagelink",
+                              "imagelink2",
+                              "audiolink",
+                              "published",
+                              "startdate",
+                              "enddate",
+                              "lat",
+                              "lon",
+                              "location",
+                              "address",
+                              "zip",
+                              "city",
+                              "country",
+                              "featured",
+                              "layer_id",
+                              "shy",
+                              "images",
+                              "annotations"
+                           ],
+                           "properties":{
+                              "id":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/id",
+                                 "type":"integer",
+                                 "title":"The Id Schema",
+                                 "default":0,
+                                 "examples":[
+                                    4
+                                 ]
+                              },
+                              "title":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/title",
+                                 "type":"string",
+                                 "title":"The Title Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "Session am Deich"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "teaser":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/teaser",
+                                 "type":"string",
+                                 "title":"The Teaser Schema",
+                                 "default":"",
+                                 "examples":[
+                                    ""
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "text":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/text",
+                                 "type":"string",
+                                 "title":"The Text Schema",
+                                 "default":"",
+                                 "examples":[
+                                    ""
+                                 ]
+                              },
+                              "link":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/link",
+                                 "type":"string",
+                                 "title":"The Link Schema",
+                                 "default":"",
+                                 "examples":[
+                                    ""
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "imagelink":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/imagelink",
+                                 "type":"null",
+                                 "title":"The Imagelink Schema",
+                                 "default":null,
+                                 "examples":[
+                                    null
+                                 ]
+                              },
+                              "imagelink2":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/imagelink2",
+                                 "type":"null",
+                                 "title":"The Imagelink Schema",
+                                 "default":null,
+                                 "examples":[
+                                    null
+                                 ]
+                              },
+                              "audiolink":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/audiolink",
+                                 "type":"null",
+                                 "title":"The Audiolink Schema",
+                                 "default":null,
+                                 "examples":[
+                                    null
+                                 ]
+                              },
+                              "published":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/published",
+                                 "type":"boolean",
+                                 "title":"The Published Schema",
+                                 "default":false,
+                                 "examples":[
+                                    true
+                                 ]
+                              },
+                              "startdate":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/startdate",
+                                 "type":"string",
+                                 "title":"The Startdate Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "2018-05-18T17:57:00.000Z"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "enddate":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/enddate",
+                                 "type":"string",
+                                 "title":"The Enddate Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "2018-05-18T17:57:00.000Z"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "lat":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/lat",
+                                 "type":"string",
+                                 "title":"The Lat Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "53.532969"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "lon":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/lon",
+                                 "type":"string",
+                                 "title":"The Lon Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "10.0367449"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "location":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/location",
+                                 "type":"string",
+                                 "title":"The Location Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "Billwerder Neuer Deich"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "address":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/address",
+                                 "type":"string",
+                                 "title":"The Address Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "Billwerder Neuer Deich undefined"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "zip":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/zip",
+                                 "type":"string",
+                                 "title":"The Zip Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "20539"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "city":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/city",
+                                 "type":"string",
+                                 "title":"The City Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "Hamburg"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "country":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/country",
+                                 "type":"string",
+                                 "title":"The Country Schema",
+                                 "default":"",
+                                 "examples":[
+                                    ""
+                                 ]
+                              },
+                              "featured":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/featured",
+                                 "type":"null",
+                                 "title":"The Featured Schema",
+                                 "default":false,
+                                 "examples":[
+                                    true
+                                 ]
+                              },
+                              "layer_id":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/layer_id",
+                                 "type":"integer",
+                                 "title":"The Layer_id Schema",
+                                 "default":0,
+                                 "examples":[
+                                    3
+                                 ]
+                              },
+                              "icon_link":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/icon_link",
+                                 "type":"null",
+                                 "title":"The Icon Link Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "http://test.domain/path/to/the/icon/file.png"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "icon_class":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/icon_class",
+                                 "type":"null",
+                                 "title":"The Icon Class Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "marker-klass"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "icon_name":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/icon_name",
+                                 "type":"null",
+                                 "title":"The Icon Name Schema",
+                                 "default":"",
+                                 "examples":[
+                                    "Name"
+                                 ],
+                                 "pattern":"^(.*)$"
+                              },
+                              "shy":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/shy",
+                                 "type":"boolean",
+                                 "title":"The Published Schema",
+                                 "default":false,
+                                 "examples":[
+                                    true
+                                 ]
+                              },
+                              "images":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/properties/images",
+                                 "type":"array",
+                                 "title":"The Images Schema",
+                                 "items":{
+                                    "$id":"#/properties/map/properties/layer/items/properties/places/items/images/otem",
+                                    "type":"object",
+                                    "title":"The Items Schema",
+                                    "required":[
+                                       "id",
+                                       "title",
+                                       "source",
+                                       "creator",
+                                       "alt",
+                                       "sorting",
+                                       "image_linktag",
+                                       "image_url"
+                                    ],
+                                    "properties":{
+                                       "id":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/id",
+                                          "type":"integer",
+                                          "title":"The Id Schema",
+                                          "default":0,
+                                          "examples":[
+                                             4
+                                          ]
+                                       },
+                                       "title":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/title",
+                                          "type":"string",
+                                          "title":"The Title Schema",
+                                          "default":"",
+                                          "examples":[
+                                             "Session am Deich"
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       },
+                                       "source":{
+                                          "$id":"#/properties/source/properties/layer/items/properties/places/items/properties/title",
+                                          "type":"string",
+                                          "title":"The Source Schema",
+                                          "default":"",
+                                          "examples":[
+                                             "The projects archive"
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       },
+                                       "creator":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/creator",
+                                          "type":"string",
+                                          "title":"The Creator Schema",
+                                          "default":"",
+                                          "examples":[
+                                             "Photographer"
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       },
+                                       "alt":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/alt",
+                                          "type":"string",
+                                          "title":"The Alt Schema",
+                                          "default":"",
+                                          "examples":[
+                                             "Some people at the session"
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       },
+                                       "sorting":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/sorting",
+                                          "type":"string",
+                                          "title":"The Sorting Schema",
+                                          "default":"",
+                                          "examples":[
+                                             "5"
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       },
+                                       "image_linktag":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/image_linktag",
+                                          "type":"string",
+                                          "title":"The Image Linktag Schema",
+                                          "default":"",
+                                          "examples":[
+                                             ""
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       },
+                                       "image_url":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places/items/properties/image_url",
+                                          "type":"null",
+                                          "title":"The Image URL Schema",
+                                          "default":null,
+                                          "examples":[
+                                             null
+                                          ]
+                                       }
+                                    }
+                                 }
+                              },
+                              "annotations":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places/properties/annotations",
+                                 "type":"array",
+                                 "title":"The Annotations Schema",
+                                 "items":{
+                                    "$id":"#/properties/map/properties/layer/items/properties/places/items/annotations/item",
+                                    "type":"object",
+                                    "title":"The Items Schema",
+                                    "required":[
+                                       "id",
+                                       "title",
+                                       "text",
+                                       "person"
+                                    ],
+                                    "properties":{
+                                       "id":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places/annotations/properties/id",
+                                          "type":"integer",
+                                          "title":"The Id Schema",
+                                          "default":0,
+                                          "examples":[
+                                             4
+                                          ]
+                                       },
+                                       "title":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places/annotations/properties/title",
+                                          "type":"string",
+                                          "title":"The Title Schema",
+                                          "default":"",
+                                          "examples":[
+                                             "Session am Deich"
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       },
+                                       "text":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places/annotations/properties/text",
+                                          "type":"string",
+                                          "title":"The Text Schema",
+                                          "default":"",
+                                          "examples":[
+                                             "Viel Text zur Session am Deich"
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       }
+                                    }
+                                 }
+                              }
+                           }
                         }
-                      }
-                    }
+                     },
+                     "places_with_relations":{
+                        "$id":"#/properties/map/properties/layer/items/properties/places_with_relations",
+                        "type":"array",
+                        "title":"The Places Schema",
+                        "items":{
+                           "$id":"#/properties/map/properties/layer/items/properties/places_with_relations/items",
+                           "type":"object",
+                           "title":"The Items Schema",
+                           "required":[
+                              "id",
+                              "from",
+                              "to"
+                           ],
+                           "properties":{
+                              "id":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places_with_relations/items/properties/id",
+                                 "type":"integer",
+                                 "title":"The Id Schema",
+                                 "default":0,
+                                 "examples":[
+                                    4
+                                 ]
+                              },
+                              "from":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places_with_relations/properties/from",
+                                 "type":"array",
+                                 "title":"The From Schema",
+                                 "items":{
+                                    "$id":"#/properties/map/properties/layer/items/properties/places_with_relations/items/images/item",
+                                    "type":"object",
+                                    "title":"The Items Schema",
+                                    "required":[
+                                       "id",
+                                       "lat",
+                                       "lon"
+                                    ],
+                                    "properties":{
+                                       "id":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places_with_relations/items/properties/id",
+                                          "type":"integer",
+                                          "title":"The Id Schema",
+                                          "default":0,
+                                          "examples":[
+                                             4
+                                          ]
+                                       },
+                                       "lat":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places_with_relations/items/properties/lat",
+                                          "type":"string",
+                                          "title":"The Lat Schema",
+                                          "default":"",
+                                          "examples":[
+                                             "10.0"
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       },
+                                       "source":{
+                                          "$id":"#/properties/source/properties/layer/items/properties/places_with_relations/items/properties/lon",
+                                          "type":"string",
+                                          "title":"The Lon Schema",
+                                          "default":"",
+                                          "examples":[
+                                             "0.0"
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       }
+                                    }
+                                 }
+                              },
+                              "to":{
+                                 "$id":"#/properties/map/properties/layer/items/properties/places_with_relations/properties/to",
+                                 "type":"array",
+                                 "title":"The to Schema",
+                                 "items":{
+                                    "$id":"#/properties/map/properties/layer/items/properties/places_with_relations/items/images/item",
+                                    "type":"object",
+                                    "title":"The Items Schema",
+                                    "required":[
+                                       "id",
+                                       "lat",
+                                       "lon"
+                                    ],
+                                    "properties":{
+                                       "id":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places_with_relations/items/properties/id",
+                                          "type":"integer",
+                                          "title":"The Id Schema",
+                                          "default":0,
+                                          "examples":[
+                                             4
+                                          ]
+                                       },
+                                       "lat":{
+                                          "$id":"#/properties/map/properties/layer/items/properties/places_with_relations/items/properties/lat",
+                                          "type":"string",
+                                          "title":"The Lat Schema",
+                                          "default":"",
+                                          "examples":[
+                                             "10.0"
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       },
+                                       "source":{
+                                          "$id":"#/properties/source/properties/layer/items/properties/places_with_relations/items/properties/lon",
+                                          "type":"string",
+                                          "title":"The Lon Schema",
+                                          "default":"",
+                                          "examples":[
+                                             "0.0"
+                                          ],
+                                          "pattern":"^(.*)$"
+                                       }
+                                    }
+                                 }
+                              }
+                           }
+                        }
+                     }
                   }
-                }
-              },
-              "places_with_relations": {
-                "$id": "#/properties/map/properties/layer/items/properties/places_with_relations",
-                "type": "array",
-                "title": "The Places Schema",
-                "items": {
-                  "$id": "#/properties/map/properties/layer/items/properties/places_with_relations/items",
-                  "type": "object",
-                  "title": "The Items Schema",
-                  "required": [
-                    "id",
-                    "from",
-                    "to"
-                  ],
-                  "properties": {
-                    "id": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places_with_relations/items/properties/id",
-                      "type": "integer",
-                      "title": "The Id Schema",
-                      "default": 0,
-                      "examples": [
-                        4
-                      ]
-                    },
-                    "from": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places_with_relations/properties/from",
-                      "type": "array",
-                      "title": "The From Schema",
-                      "items": {
-                        "$id": "#/properties/map/properties/layer/items/properties/places_with_relations/items/images/item",
-                        "type": "object",
-                        "title": "The Items Schema",
-                        "required": [
-                          "id",
-                          "lat",
-                          "lon"
-                        ],
-                        "properties": {
-                          "id": {
-                            "$id": "#/properties/map/properties/layer/items/properties/places_with_relations/items/properties/id",
-                            "type": "integer",
-                            "title": "The Id Schema",
-                            "default": 0,
-                            "examples": [
-                              4
-                            ]
-                          },
-                          "lat": {
-                            "$id": "#/properties/map/properties/layer/items/properties/places_with_relations/items/properties/lat",
-                            "type": "string",
-                            "title": "The Lat Schema",
-                            "default": "",
-                            "examples": [
-                              "10.0"
-                            ],
-                            "pattern": "^(.*)$"
-                          },
-                          "source": {
-                            "$id": "#/properties/source/properties/layer/items/properties/places_with_relations/items/properties/lon",
-                            "type": "string",
-                            "title": "The Lon Schema",
-                            "default": "",
-                            "examples": [
-                              "0.0"
-                            ],
-                            "pattern": "^(.*)$"
-                          }
-                        }
-                      }
-                    },
-                    "to": {
-                      "$id": "#/properties/map/properties/layer/items/properties/places_with_relations/properties/to",
-                      "type": "array",
-                      "title": "The to Schema",
-                      "items": {
-                        "$id": "#/properties/map/properties/layer/items/properties/places_with_relations/items/images/item",
-                        "type": "object",
-                        "title": "The Items Schema",
-                        "required": [
-                          "id",
-                          "lat",
-                          "lon"
-                        ],
-                        "properties": {
-                          "id": {
-                            "$id": "#/properties/map/properties/layer/items/properties/places_with_relations/items/properties/id",
-                            "type": "integer",
-                            "title": "The Id Schema",
-                            "default": 0,
-                            "examples": [
-                              4
-                            ]
-                          },
-                          "lat": {
-                            "$id": "#/properties/map/properties/layer/items/properties/places_with_relations/items/properties/lat",
-                            "type": "string",
-                            "title": "The Lat Schema",
-                            "default": "",
-                            "examples": [
-                              "10.0"
-                            ],
-                            "pattern": "^(.*)$"
-                          },
-                          "source": {
-                            "$id": "#/properties/source/properties/layer/items/properties/places_with_relations/items/properties/lon",
-                            "type": "string",
-                            "title": "The Lon Schema",
-                            "default": "",
-                            "examples": [
-                              "0.0"
-                            ],
-                            "pattern": "^(.*)$"
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
+               }
             }
-          }
-        }
+         }
       }
-    }
-  }
+   }
 }


### PR DESCRIPTION
Sometimes the map's viewport should be different then the extent of all defined places. E.g. if the focus of the map should on on specific area (a city) while there are other places on the map/layer outside this area.

There is already the feature to manually set the map extent on map layer. Here we'd just offer an simple option to set that lat/lng's and zoom level (1-18) for a layer.