### PR TITLE
Fix before_save behavior on attachment upload

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -3,10 +3,12 @@
 class Image < ApplicationRecord
   belongs_to :place
 
+  attr_accessor :skip_beforesave_callback
+
+  before_save :strip_exif_data, unless: :skip_beforesave_callback
+
   has_one_attached :file
   delegate_missing_to :file
-
-  before_save :strip_exif_data
 
   validates :title, presence: true
   validate :check_file_presence
@@ -15,6 +17,7 @@ class Image < ApplicationRecord
   scope :sorted, -> { order(sorting: :asc) }
   scope :sorted_by_place, ->(place_id) { where('place_id': place_id).order(sorting: :asc) }
   scope :preview, ->(place_id) { where('place_id': place_id, 'preview': true) }
+  scope :without_attached_file, -> { left_joins(:file_attachment).where('active_storage_attachments.id IS NULL') }
 
   def image_filename
     file.filename if file&.attached?
@@ -63,7 +66,15 @@ class Image < ApplicationRecord
 
     filename = file.filename.to_s
     attachment_path = "#{Dir.tmpdir}/#{file.filename}"
-    tmp_new_image = File.read(attachment_changes['file'].attachable[:io])
+
+    attachable = if attachment_changes['file'].attachable.is_a?(Hash) && attachment_changes['file'].attachable[:io]
+                   attachment_changes['file'].attachable[:io]
+                 else
+                   attachment_changes['file'].attachable
+                 end
+
+    tmp_new_image = File.read(attachable)
+
     File.open(attachment_path, 'wb') do |tmp_file|
       tmp_file.write(tmp_new_image)
       tmp_file.close
@@ -72,6 +83,7 @@ class Image < ApplicationRecord
     tmp_image.auto_orient # Before stripping
     tmp_image.strip # Strip Exif
     tmp_image.write attachment_path
+    self.skip_beforesave_callback = true
     file.attach(io: File.open(attachment_path), filename: file.filename)
   end
 

--- a/spec/helpers/images_helper_spec.rb
+++ b/spec/helpers/images_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ImagesHelper, type: :helper do
     it 'it returns an image link tag' do
       p = create(:place)
       i = build(:image, place: p)
-      i.file.attach(io: File.open(Rails.root.join('spec', 'support', 'files', 'test.jpg')), filename: 'attachment.jpg', content_type: 'image/jpeg')
+      i.file.attach(io: File.open(Rails.root.join('spec', 'support', 'files', 'test.jpg')), filename: 'attachment.jpg', content_type: 'image/jepg')
       i.save!
       i.reload
       expect(helper.image_linktag(i.file)).to eq("<img src=\"#{polymorphic_url(i.file.variant(resize: '800x800').processed)}\" title=\"\">")

--- a/spec/helpers/places_helper_spec.rb
+++ b/spec/helpers/places_helper_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe PlacesHelper, type: :helper do
   describe 'icon_link' do
     it 'it returns an polymorphic icon link' do
       i = Icon.new
-      i.file.attach(io: File.open(Rails.root.join('spec', 'support', 'files', 'test.jpg')), filename: 'attachment.jpg', content_type: 'image/jpeg')
+      i.file.attach(io: File.open(Rails.root.join('spec', 'support', 'files', 'test.jpg')), filename: 'attachment.jpg', content_type: 'image/jepg')
       expect(helper.icon_link(i.file)).to eq("<img src=\"http://test.host#{rails_blob_path(i.file)}\">")
     end
   end

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe Image, type: :model do
     end
     it 'should remove EXIF data' do
       i = FactoryBot.build(:image, place: @p2)
-      image.file.attach(io: File.open(Rails.root.join('spec', 'support', 'files', 'test.txt')), filename: 'attachment.txt', content_type: 'txt/plain')
+      i.file.attach(io: File.open(Rails.root.join('spec', 'support', 'files', 'test-with-exif-data.jpg')), filename: 'attachment.jpg', content_type: 'image/jpeg')
       i.save!
       i.reload
       expect(i.get_exif_data).to eq({})


### PR DESCRIPTION
This is a follow up/rewrite  to  PR #291 

Since rail 6 the workflow of the uploading has changed (see https://stackoverflow.com/a/57591408)
Further reading: https://github.com/rails/rails/pull/33303 & https://github.com/rails/rails/pull/37005

So not only does the moment of upload change, but we have a difference in the  behavior of an upload file vs a file from local file system (attachment_changes['file'].attachable[:io] vs attachment_changes['file'].attachable).
This pr tries to handle this. 

Furthermore there is a switch to stop attachment change tracking and infinite loops by disabling the before_save hook. 


