### PR TITLE
Feat: Performance Improvements without caching #370

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -396,6 +396,9 @@ Style/RedundantArgument:
 Style/RedundantArrayConstructor:
   Enabled: true
 
+Style/RedundantCondition:
+  Enabled: false
+
 Style/RedundantConstantBase:
   Enabled: true
 

--- a/app/controllers/public/layers_controller.rb
+++ b/app/controllers/public/layers_controller.rb
@@ -27,6 +27,7 @@ class Public::LayersController < ActionController::Base
                 else
                   @layer.places.published
                 end
+      @places = @places.includes(:images, :annotations, :icon, audio_attachment: :blob, relations_froms: { relation_from: [:layer], relation_to: [:layer] })
     end
 
     respond_to do |format|

--- a/app/controllers/public/maps_controller.rb
+++ b/app/controllers/public/maps_controller.rb
@@ -28,6 +28,7 @@ class Public::MapsController < ActionController::Base
     respond_to do |format|
       @map_layers = @map.layers if @map&.layers
       if @map_layers.present?
+        @map_layers = @map_layers.includes(:image_attachment)
         format.json { render :show, location: @map }
       elsif @map.present?
         format.json { render :show, location: @map }

--- a/app/controllers/public/maps_controller.rb
+++ b/app/controllers/public/maps_controller.rb
@@ -26,9 +26,11 @@ class Public::MapsController < ActionController::Base
     @map = Map.published.find_by_slug(params[:id]) || Map.published.find_by_id(params[:id])
 
     respond_to do |format|
-      @map_layers = @map.layers if @map&.layers
+      @map_layers = @map.layers.published if @map&.layers
       if @map_layers.present?
-        @map_layers = @map_layers.includes(:image_attachment)
+        @map_layers = @map_layers
+                      .includes(:image_attachment, places: [:icon, :annotations, { images: { file_attachment: :blob }, audio_attachment: :blob, relations_froms: %i[relation_from relation_to] }])
+                      .where(places: { published: true })
         format.json { render :show, location: @map }
       elsif @map.present?
         format.json { render :show, location: @map }

--- a/app/controllers/public/maps_controller.rb
+++ b/app/controllers/public/maps_controller.rb
@@ -44,7 +44,7 @@ class Public::MapsController < ActionController::Base
   def allplaces
     @map = Map.published.find_by_slug(params[:id]) || Map.published.find_by_id(params[:id])
     respond_to do |format|
-      @map_layers = @map.layers if @map&.layers
+      @map_layers = @map.layers.includes(places: [:icon, :annotations, { images: { file_attachment: :blob }, audio_attachment: :blob, relations_froms: %i[relation_from relation_to] }]) if @map&.layers
       @allplaces = []
 
       if @map_layers.present?

--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -2,7 +2,7 @@
 
 include ActionView::Helpers::NumberHelper
 class Layer < ApplicationRecord
-  belongs_to :map, touch: true
+  belongs_to :map
   has_many :places, dependent: :destroy
   has_one :submission_config
   has_many :build_logs, dependent: :destroy

--- a/app/models/layer.rb
+++ b/app/models/layer.rb
@@ -2,7 +2,7 @@
 
 include ActionView::Helpers::NumberHelper
 class Layer < ApplicationRecord
-  belongs_to :map
+  belongs_to :map, touch: true
   has_many :places, dependent: :destroy
   has_one :submission_config
   has_many :build_logs, dependent: :destroy

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -37,6 +37,12 @@ class Place < ApplicationRecord
 
   scope :published, -> { where(published: true) }
 
+  scope :with_attached_audio, -> { includes(audio_attachment: :blob) }
+  scope :with_icon, -> { includes(:icon) }
+  scope :with_annotations, -> { includes(:annotations) }
+  scope :with_images, -> { includes(images: {file_attachment: :blob}) }
+  scope :with_relations, -> { includes(relations_froms: [:relation_from, :relation_to] ) }
+
   attr_accessor :startdate_date, :startdate_time, :enddate_date, :enddate_time
 
   after_initialize :sensitive_location

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -3,7 +3,7 @@
 require 'csv'
 
 class Place < ApplicationRecord
-  belongs_to :layer, touch: true
+  belongs_to :layer
   belongs_to :icon, optional: true
 
   acts_as_taggable_on :tags
@@ -102,10 +102,6 @@ class Place < ApplicationRecord
     [x + long.to_f, y + lat.to_f]
   end
 
-  def layer_id
-    layer.id
-  end
-
   def layer_title
     layer.title
   end
@@ -143,7 +139,7 @@ class Place < ApplicationRecord
   end
 
   def show_link
-    ApplicationController.helpers.show_link(title, layer.map.id, layer.id, id)
+    ApplicationController.helpers.show_link(title, layer.map_id, layer.id, id)
   end
 
   def edit_link
@@ -163,7 +159,7 @@ class Place < ApplicationRecord
   end
 
   def imagelink2
-    i = Image.preview(id)
+    i = images.filter { |image| image.place_id == id && image.preview }
     i.count.positive? ? ApplicationController.helpers.image_link(i.first) : ''
   end
 

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -3,7 +3,7 @@
 require 'csv'
 
 class Place < ApplicationRecord
-  belongs_to :layer
+  belongs_to :layer, touch: true
   belongs_to :icon, optional: true
 
   acts_as_taggable_on :tags

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -37,12 +37,6 @@ class Place < ApplicationRecord
 
   scope :published, -> { where(published: true) }
 
-  scope :with_attached_audio, -> { includes(audio_attachment: :blob) }
-  scope :with_icon, -> { includes(:icon) }
-  scope :with_annotations, -> { includes(:annotations) }
-  scope :with_images, -> { includes(images: {file_attachment: :blob}) }
-  scope :with_relations, -> { includes(relations_froms: [:relation_from, :relation_to] ) }
-
   attr_accessor :startdate_date, :startdate_time, :enddate_date, :enddate_time
 
   after_initialize :sensitive_location

--- a/app/views/public/layers/show.geojson.jbuilder
+++ b/app/views/public/layers/show.geojson.jbuilder
@@ -6,7 +6,7 @@ if @layer&.published
   json.text @layer.text
   json.id @layer.id
 
-  json.features @layer.places do |place|
+  json.features @places do |place|
     next unless place.published
 
     json.type 'Feature'

--- a/app/views/public/layers/show.json.jbuilder
+++ b/app/views/public/layers/show.json.jbuilder
@@ -1,43 +1,41 @@
 # frozen_string_literal: true
 
 json.layer do
-  json.cache! @layer do
-    next unless @layer.published
+  next unless @layer.published
 
-    json.call(@layer, :id, :title, :subtitle, :text, :teaser, :credits, :image_link, :image_filename, :backgroundimage_link, :backgroundimage_filename, :favicon_link, :favicon_filename, :color, :style, :basemap_url, :basemap_attribution, :background_color, :tooltip_display_mode, :mapcenter_lat, :mapcenter_lon, :zoom, :relations_bending, :relations_coloring, :created_at, :updated_at, :published)
-    json.places do
-      json.array! @places do |place|
-        next unless place.published
+  json.call(@layer, :id, :title, :subtitle, :text, :teaser, :credits, :image_link, :image_filename, :backgroundimage_link, :backgroundimage_filename, :favicon_link, :favicon_filename, :color, :style, :basemap_url, :basemap_attribution, :background_color, :tooltip_display_mode, :mapcenter_lat, :mapcenter_lon, :zoom, :relations_bending, :relations_coloring, :created_at, :updated_at, :published)
+  json.places do
+    json.array! @places do |place|
+      next unless place.published
 
-        json.call(place, :id, :uid, :title, :subtitle, :teaser, :text, :sources, :link, :imagelink, :imagelink2, :audiolink, :published, :date_with_qualifier, :startdate, :enddate, :startdate_qualifier, :enddate_qualifier, :location, :address, :zip, :city, :text, :country, :featured, :layer_id, :icon_link, :icon_class, :icon_name)
-        json.lat place.public_lat
-        json.lon place.public_lon
-        json.annotations place.annotations do |annotation|
-          json.extract! annotation, :id, :title, :text, :person_name, :audiolink
-        end
-        json.images do
-          json.array! place.images.order('sorting ASC') do |image|
-            json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url, :image_path, :image_filename, :image_on_disk)
-          end
+      json.call(place, :id, :uid, :title, :subtitle, :teaser, :text, :sources, :link, :imagelink, :imagelink2, :audiolink, :published, :date_with_qualifier, :startdate, :enddate, :startdate_qualifier, :enddate_qualifier, :location, :address, :zip, :city, :text, :country, :featured, :layer_id, :icon_link, :icon_class, :icon_name)
+      json.lat place.public_lat
+      json.lon place.public_lon
+      json.annotations place.annotations do |annotation|
+        json.extract! annotation, :id, :title, :text, :person_name, :audiolink
+      end
+      json.images do
+        json.array!(place.images.sort_by(&:sorting)) do |image|
+          json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url, :image_path, :image_filename, :image_on_disk)
         end
       end
     end
-    json.places_with_relations @places do |place|
-      next unless place.published
+  end
+  json.places_with_relations @places do |place|
+    next unless place.published
 
-      if place.relations_froms.count.positive?
-        json.relations place.relations_froms do |relation|
-          json.id relation.id
-          json.from do
-            json.extract! relation.relation_from, :id, :title, :show_link, :published, :layer_id
-            json.lat relation.relation_from.public_lat
-            json.lon relation.relation_from.public_lon
-          end
-          json.to do
-            json.extract! relation.relation_to, :id, :title, :show_link, :published, :layer_id
-            json.lat relation.relation_to.public_lat
-            json.lon relation.relation_to.public_lon
-          end
+    if place.relations_froms.size.positive?
+      json.relations place.relations_froms do |relation|
+        json.id relation.id
+        json.from do
+          json.extract! relation.relation_from, :id, :title, :show_link, :published, :layer_id
+          json.lat relation.relation_from.public_lat
+          json.lon relation.relation_from.public_lon
+        end
+        json.to do
+          json.extract! relation.relation_to, :id, :title, :show_link, :published, :layer_id
+          json.lat relation.relation_to.public_lat
+          json.lon relation.relation_to.public_lon
         end
       end
     end

--- a/app/views/public/layers/show.json.jbuilder
+++ b/app/views/public/layers/show.json.jbuilder
@@ -1,41 +1,43 @@
 # frozen_string_literal: true
 
 json.layer do
-  next unless @layer.published
+  json.cache! @layer do
+    next unless @layer.published
 
-  json.call(@layer, :id, :title, :subtitle, :text, :teaser, :credits, :image_link, :image_filename, :backgroundimage_link, :backgroundimage_filename, :favicon_link, :favicon_filename, :color, :style, :basemap_url, :basemap_attribution, :background_color, :tooltip_display_mode, :mapcenter_lat, :mapcenter_lon, :zoom, :relations_bending, :relations_coloring, :created_at, :updated_at, :published)
-  json.places do
-    json.array! @places do |place|
-      next unless place.published
+    json.call(@layer, :id, :title, :subtitle, :text, :teaser, :credits, :image_link, :image_filename, :backgroundimage_link, :backgroundimage_filename, :favicon_link, :favicon_filename, :color, :style, :basemap_url, :basemap_attribution, :background_color, :tooltip_display_mode, :mapcenter_lat, :mapcenter_lon, :zoom, :relations_bending, :relations_coloring, :created_at, :updated_at, :published)
+    json.places do
+      json.array! @places do |place|
+        next unless place.published
 
-      json.call(place, :id, :uid, :title, :subtitle, :teaser, :text, :sources, :link, :imagelink, :imagelink2, :audiolink, :published, :date_with_qualifier, :startdate, :enddate, :startdate_qualifier, :enddate_qualifier, :location, :address, :zip, :city, :text, :country, :featured, :layer_id, :icon_link, :icon_class, :icon_name)
-      json.lat place.public_lat
-      json.lon place.public_lon
-      json.annotations place.annotations do |annotation|
-        json.extract! annotation, :id, :title, :text, :person_name, :audiolink
-      end
-      json.images do
-        json.array! place.images.order('sorting ASC') do |image|
-          json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url, :image_path, :image_filename, :image_on_disk)
+        json.call(place, :id, :uid, :title, :subtitle, :teaser, :text, :sources, :link, :imagelink, :imagelink2, :audiolink, :published, :date_with_qualifier, :startdate, :enddate, :startdate_qualifier, :enddate_qualifier, :location, :address, :zip, :city, :text, :country, :featured, :layer_id, :icon_link, :icon_class, :icon_name)
+        json.lat place.public_lat
+        json.lon place.public_lon
+        json.annotations place.annotations do |annotation|
+          json.extract! annotation, :id, :title, :text, :person_name, :audiolink
+        end
+        json.images do
+          json.array! place.images.order('sorting ASC') do |image|
+            json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url, :image_path, :image_filename, :image_on_disk)
+          end
         end
       end
     end
-  end
-  json.places_with_relations @places do |place|
-    next unless place.published
+    json.places_with_relations @places do |place|
+      next unless place.published
 
-    if place.relations_froms.count.positive?
-      json.relations place.relations_froms do |relation|
-        json.id relation.id
-        json.from do
-          json.extract! relation.relation_from, :id, :title, :show_link, :published, :layer_id
-          json.lat relation.relation_from.public_lat
-          json.lon relation.relation_from.public_lon
-        end
-        json.to do
-          json.extract! relation.relation_to, :id, :title, :show_link, :published, :layer_id
-          json.lat relation.relation_to.public_lat
-          json.lon relation.relation_to.public_lon
+      if place.relations_froms.count.positive?
+        json.relations place.relations_froms do |relation|
+          json.id relation.id
+          json.from do
+            json.extract! relation.relation_from, :id, :title, :show_link, :published, :layer_id
+            json.lat relation.relation_from.public_lat
+            json.lon relation.relation_from.public_lon
+          end
+          json.to do
+            json.extract! relation.relation_to, :id, :title, :show_link, :published, :layer_id
+            json.lat relation.relation_to.public_lat
+            json.lon relation.relation_to.public_lon
+          end
         end
       end
     end

--- a/app/views/public/maps/allplaces.json.jbuilder
+++ b/app/views/public/maps/allplaces.json.jbuilder
@@ -18,11 +18,11 @@ json.map do
         json.extract! annotation, :id, :title, :text, :person_name, :audiolink
       end
       json.images do
-        json.array! place.images.order('sorting ASC') do |image|
+        json.array! place.images.sort_by(&:sorting) do |image|
           json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url)
         end
       end
-      if place.relations_froms.count.positive?
+      if place.relations_froms.size.positive?
         json.relations place.relations_froms do |relation|
           json.id relation.id
           json.from do

--- a/app/views/public/maps/show.json.jbuilder
+++ b/app/views/public/maps/show.json.jbuilder
@@ -1,50 +1,48 @@
 # frozen_string_literal: true
 
 json.map do
-  json.cache! @map do
-    next unless @map.published
+  next unless @map.published
 
-    json.call(@map, :id, :title, :subtitle, :text, :credits, :image_link, :created_at, :updated_at, :published)
-    json.owner @map.group.title
-    json.iconset @map.iconset, :title, :icon_anchor, :icon_size, :popup_anchor, :class_name if @map.iconset
-    json.layer do
-      json.array! @map.layers.published do |layer|
-        next unless layer.published
+  json.call(@map, :id, :title, :subtitle, :text, :credits, :image_link, :created_at, :updated_at, :published)
+  json.owner @map.group.title
+  json.iconset @map.iconset, :title, :icon_anchor, :icon_size, :popup_anchor, :class_name if @map.iconset
+  json.layer do
+    json.array! @map_layers.published do |layer|
+      next unless layer.published
 
-        json.call(layer, :id, :title, :subtitle, :text, :teaser, :credits, :image_link, :color, :created_at, :updated_at, :published)
-        json.places do
-          json.array! layer.places.published do |place|
-            next unless place.published
+      json.call(layer, :id, :title, :subtitle, :text, :teaser, :credits, :image_link, :color, :created_at, :updated_at, :published)
+      json.places do
+        json.array! layer.places.published.with_attached_audio.with_icon.with_annotations.with_images do |place|
+          next unless place.published
 
-            json.call(place, :id, :uid, :title, :subtitle, :teaser, :text, :sources, :link, :imagelink, :imagelink2, :audiolink, :published, :date_with_qualifier, :startdate, :enddate, :location, :address, :zip, :city, :text, :country, :featured, :shy, :layer_id, :icon_link, :icon_class, :icon_name)
-            json.lat place.public_lat
-            json.lon place.public_lon
-            json.annotations place.annotations do |annotation|
-              json.extract! annotation, :id, :title, :text, :person_name, :audiolink
-            end
-            json.images do
-              json.array! place.images.order('sorting ASC') do |image|
-                json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url)
-              end
+          json.call(place, :id, :uid, :title, :subtitle, :teaser, :text, :sources, :link, :imagelink, :imagelink2, :audiolink, :published, :date_with_qualifier, :startdate, :enddate, :location, :address, :zip, :city, :text, :country, :featured, :shy, :layer_id, :icon_link, :icon_class, :icon_name)
+          json.lat place.public_lat
+          json.lon place.public_lon
+          json.annotations place.annotations do |annotation|
+            json.extract! annotation, :id, :title, :text, :person_name, :audiolink
+          end
+          json.images do
+            json.array! place.images.sort_by(&:sorting) do |image|
+              json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url)
             end
           end
         end
-        json.places_with_relations layer.places.published do |place|
-          next unless place.published
+      end
+      json.places_with_relations layer.places.published.with_relations do |place|
+        next unless place.published
 
-          if place.relations_froms.count.positive?
-            json.relations place.relations_froms do |relation|
-              json.id relation.id
-              json.from do
-                json.extract! relation.relation_from, :id
-                json.lat relation.relation_from.public_lat
-                json.lon relation.relation_from.public_lon
-              end
-              json.to do
-                json.extract! relation.relation_to, :id
-                json.lat relation.relation_to.public_lat
-                json.lon relation.relation_to.public_lon
-              end
+        if place.relations_froms.size.positive?
+          json.relations place.relations_froms do |relation|
+            json.id relation.id
+            json.from do
+              json.extract! relation.relation_from, :id
+              json.lat relation.relation_from.public_lat
+              json.lon relation.relation_from.public_lon
+            end
+            json.to do
+              json.extract! relation.relation_to, :id
+              json.lat relation.relation_to.public_lat
+              json.lon relation.relation_to.public_lon
             end
           end
         end
@@ -52,3 +50,4 @@ json.map do
     end
   end
 end
+

--- a/app/views/public/maps/show.json.jbuilder
+++ b/app/views/public/maps/show.json.jbuilder
@@ -50,4 +50,3 @@ json.map do
     end
   end
 end
-

--- a/app/views/public/maps/show.json.jbuilder
+++ b/app/views/public/maps/show.json.jbuilder
@@ -1,48 +1,50 @@
 # frozen_string_literal: true
 
 json.map do
-  next unless @map.published
+  json.cache! @map do
+    next unless @map.published
 
-  json.call(@map, :id, :title, :subtitle, :text, :credits, :image_link, :created_at, :updated_at, :published)
-  json.owner @map.group.title
-  json.iconset @map.iconset, :title, :icon_anchor, :icon_size, :popup_anchor, :class_name if @map.iconset
-  json.layer do
-    json.array! @map.layers.published do |layer|
-      next unless layer.published
+    json.call(@map, :id, :title, :subtitle, :text, :credits, :image_link, :created_at, :updated_at, :published)
+    json.owner @map.group.title
+    json.iconset @map.iconset, :title, :icon_anchor, :icon_size, :popup_anchor, :class_name if @map.iconset
+    json.layer do
+      json.array! @map.layers.published do |layer|
+        next unless layer.published
 
-      json.call(layer, :id, :title, :subtitle, :text, :teaser, :credits, :image_link, :color, :created_at, :updated_at, :published)
-      json.places do
-        json.array! layer.places.published do |place|
-          next unless place.published
+        json.call(layer, :id, :title, :subtitle, :text, :teaser, :credits, :image_link, :color, :created_at, :updated_at, :published)
+        json.places do
+          json.array! layer.places.published do |place|
+            next unless place.published
 
-          json.call(place, :id, :uid, :title, :subtitle, :teaser, :text, :sources, :link, :imagelink, :imagelink2, :audiolink, :published, :date_with_qualifier, :startdate, :enddate, :location, :address, :zip, :city, :text, :country, :featured, :shy, :layer_id, :icon_link, :icon_class, :icon_name)
-          json.lat place.public_lat
-          json.lon place.public_lon
-          json.annotations place.annotations do |annotation|
-            json.extract! annotation, :id, :title, :text, :person_name, :audiolink
-          end
-          json.images do
-            json.array! place.images.order('sorting ASC') do |image|
-              json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url)
+            json.call(place, :id, :uid, :title, :subtitle, :teaser, :text, :sources, :link, :imagelink, :imagelink2, :audiolink, :published, :date_with_qualifier, :startdate, :enddate, :location, :address, :zip, :city, :text, :country, :featured, :shy, :layer_id, :icon_link, :icon_class, :icon_name)
+            json.lat place.public_lat
+            json.lon place.public_lon
+            json.annotations place.annotations do |annotation|
+              json.extract! annotation, :id, :title, :text, :person_name, :audiolink
+            end
+            json.images do
+              json.array! place.images.order('sorting ASC') do |image|
+                json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url)
+              end
             end
           end
         end
-      end
-      json.places_with_relations layer.places.published do |place|
-        next unless place.published
+        json.places_with_relations layer.places.published do |place|
+          next unless place.published
 
-        if place.relations_froms.count.positive?
-          json.relations place.relations_froms do |relation|
-            json.id relation.id
-            json.from do
-              json.extract! relation.relation_from, :id
-              json.lat relation.relation_from.public_lat
-              json.lon relation.relation_from.public_lon
-            end
-            json.to do
-              json.extract! relation.relation_to, :id
-              json.lat relation.relation_to.public_lat
-              json.lon relation.relation_to.public_lon
+          if place.relations_froms.count.positive?
+            json.relations place.relations_froms do |relation|
+              json.id relation.id
+              json.from do
+                json.extract! relation.relation_from, :id
+                json.lat relation.relation_from.public_lat
+                json.lon relation.relation_from.public_lon
+              end
+              json.to do
+                json.extract! relation.relation_to, :id
+                json.lat relation.relation_to.public_lat
+                json.lon relation.relation_to.public_lon
+              end
             end
           end
         end

--- a/app/views/public/maps/show.json.jbuilder
+++ b/app/views/public/maps/show.json.jbuilder
@@ -7,12 +7,12 @@ json.map do
   json.owner @map.group.title
   json.iconset @map.iconset, :title, :icon_anchor, :icon_size, :popup_anchor, :class_name if @map.iconset
   json.layer do
-    json.array! @map_layers.published do |layer|
+    json.array! @map_layers do |layer|
       next unless layer.published
 
       json.call(layer, :id, :title, :subtitle, :text, :teaser, :credits, :image_link, :color, :created_at, :updated_at, :published)
       json.places do
-        json.array! layer.places.published.with_attached_audio.with_icon.with_annotations.with_images do |place|
+        json.array! layer.places do |place|
           next unless place.published
 
           json.call(place, :id, :uid, :title, :subtitle, :teaser, :text, :sources, :link, :imagelink, :imagelink2, :audiolink, :published, :date_with_qualifier, :startdate, :enddate, :location, :address, :zip, :city, :text, :country, :featured, :shy, :layer_id, :icon_link, :icon_class, :icon_name)
@@ -28,7 +28,7 @@ json.map do
           end
         end
       end
-      json.places_with_relations layer.places.published.with_relations do |place|
+      json.places_with_relations layer.places do |place|
         next unless place.published
 
         if place.relations_froms.size.positive?

--- a/spec/controllers/public/layers_controller_spec.rb
+++ b/spec/controllers/public/layers_controller_spec.rb
@@ -93,6 +93,41 @@ RSpec.describe Public::LayersController, type: :controller do
         expect(response).to have_http_status(403)
         expect(JSON.parse(response.body)['error']).to match(/Layer not accessible/)
       end
+
+      context 'with measured performance to prevent n+1 queries' do
+        before do
+          @map = FactoryBot.create(:map, published: true)
+          @layer = FactoryBot.create(:layer, map_id: @map.id, published: true)
+          # Create 6 places with relations between them
+          3.times do
+            place1 = FactoryBot.create(:place, :with_audio, layer_id: @layer.id, published: true)
+            place2 = FactoryBot.create(:place, layer_id: @layer.id, published: true)
+            FactoryBot.create(:relation, relation_from: place1, relation_to: place2)
+          end
+        end
+
+        def trigger
+          get :show, params: { id: @layer.to_param, map_id: @map.id, format: 'json' }, session: valid_session
+        end
+
+        it 'makes the same number of queries, no matter how many records are delivered' do
+          # Measure queries before adding additional records
+          x = count_queries { trigger }
+
+          # Create 200 additional places with relations between them
+          100.times do
+            place1 = FactoryBot.create(:place, :with_audio, layer_id: @layer.id, published: true)
+            place2 = FactoryBot.create(:place, layer_id: @layer.id, published: true)
+            FactoryBot.create(:relation, relation_from: place1, relation_to: place2)
+          end
+
+          # Measure queries after adding records
+          y = count_queries { trigger }
+
+          # Ensure query count remains the same
+          expect(x).to eq(y)
+        end
+      end
     end
 
     describe 'GET #show w/GeoJSON format' do

--- a/spec/controllers/public/layers_controller_spec.rb
+++ b/spec/controllers/public/layers_controller_spec.rb
@@ -93,41 +93,6 @@ RSpec.describe Public::LayersController, type: :controller do
         expect(response).to have_http_status(403)
         expect(JSON.parse(response.body)['error']).to match(/Layer not accessible/)
       end
-
-      context 'with measured performance to prevent n+1 queries' do
-        before do
-          @map = FactoryBot.create(:map, published: true)
-          @layer = FactoryBot.create(:layer, map_id: @map.id, published: true)
-          # Create 6 places with relations between them
-          3.times do
-            place1 = FactoryBot.create(:place, :with_audio, layer_id: @layer.id, published: true)
-            place2 = FactoryBot.create(:place, layer_id: @layer.id, published: true)
-            FactoryBot.create(:relation, relation_from: place1, relation_to: place2)
-          end
-        end
-
-        def trigger
-          get :show, params: { id: @layer.to_param, map_id: @map.id, format: 'json' }, session: valid_session
-        end
-
-        it 'makes the same number of queries, no matter how many records are delivered' do
-          # Measure queries before adding additional records
-          x = count_queries { trigger }
-
-          # Create 3 additional places with relations between them
-          3.times do
-            place1 = FactoryBot.create(:place, :with_audio, layer_id: @layer.id, published: true)
-            place2 = FactoryBot.create(:place, layer_id: @layer.id, published: true)
-            FactoryBot.create(:relation, relation_from: place1, relation_to: place2)
-          end
-
-          # Measure queries after adding records
-          y = count_queries { trigger }
-
-          # Ensure query count remains the same
-          expect(x).to eq(y)
-        end
-      end
     end
 
     describe 'GET #show w/GeoJSON format' do
@@ -165,6 +130,48 @@ RSpec.describe Public::LayersController, type: :controller do
         layer = Layer.create! valid_attributes
         get :show, params: { id: layer.to_param, map_id: @map.id, format: 'zip' }, session: valid_session
         expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'preventing n+1 queries for GET #show w/JSON and w/GeoJSON format' do
+      before do
+        @map = FactoryBot.create(:map, published: true)
+        @layer = FactoryBot.create(:layer, map_id: @map.id, published: true)
+        # Create 6 places with relations between them
+        3.times do
+          place1 = FactoryBot.create(:place, :with_audio, layer_id: @layer.id, published: true)
+          place2 = FactoryBot.create(:place, layer_id: @layer.id, published: true)
+          FactoryBot.create(:relation, relation_from: place1, relation_to: place2)
+        end
+      end
+
+      def trigger_show_json
+        get :show, params: { id: @layer.to_param, map_id: @map.id, format: 'json' }, session: valid_session
+      end
+
+      def trigger_show_geomap
+        get :show, params: { id: @layer.to_param, map_id: @map.id, format: 'geojson' }, session: valid_session
+      end
+
+      it 'makes the same number of queries, no matter how many records are delivered' do
+        # Measure queries before adding additional records
+        x_json = count_queries { trigger_show_json }
+        x_geo = count_queries { trigger_show_geomap }
+
+        # Create 3 additional places with relations between them
+        3.times do
+          place1 = FactoryBot.create(:place, :with_audio, layer_id: @layer.id, published: true)
+          place2 = FactoryBot.create(:place, layer_id: @layer.id, published: true)
+          FactoryBot.create(:relation, relation_from: place1, relation_to: place2)
+        end
+
+        # Measure queries after adding records
+        y_json = count_queries { trigger_show_json }
+        y_geo = count_queries { trigger_show_geomap }
+
+        # Ensure query count remains the same
+        expect(x_json).to eq(y_json)
+        expect(x_geo).to eq(y_geo)
       end
     end
   end

--- a/spec/controllers/public/layers_controller_spec.rb
+++ b/spec/controllers/public/layers_controller_spec.rb
@@ -114,8 +114,8 @@ RSpec.describe Public::LayersController, type: :controller do
           # Measure queries before adding additional records
           x = count_queries { trigger }
 
-          # Create 200 additional places with relations between them
-          100.times do
+          # Create 3 additional places with relations between them
+          3.times do
             place1 = FactoryBot.create(:place, :with_audio, layer_id: @layer.id, published: true)
             place2 = FactoryBot.create(:place, layer_id: @layer.id, published: true)
             FactoryBot.create(:relation, relation_from: place1, relation_to: place2)

--- a/spec/controllers/public/maps_controller_spec.rb
+++ b/spec/controllers/public/maps_controller_spec.rb
@@ -83,10 +83,10 @@ RSpec.describe Public::MapsController, type: :controller do
           # Measure queries before adding additional records
           x = count_queries { trigger }
 
-          # Create 10 additional layers and 2000 additional places with relations between them
-          10.times do
+          # Create 3 additional layers and 18 additional places with relations between them
+          3.times do
             layer = FactoryBot.create(:layer, map_id: @map.id, published: true)
-            100.times do
+            3.times do
               place1 = FactoryBot.create(:place, :with_audio, layer_id: layer.id, published: true)
               place2 = FactoryBot.create(:place, layer_id: layer.id, published: true)
               FactoryBot.create(:relation, relation_from: place1, relation_to: place2)

--- a/spec/controllers/public/maps_controller_spec.rb
+++ b/spec/controllers/public/maps_controller_spec.rb
@@ -62,6 +62,44 @@ RSpec.describe Public::MapsController, type: :controller do
         expect(response).to have_http_status(403)
         expect(JSON.parse(response.body)['error']).to match(/Map not accessible/)
       end
+
+      context 'with measured performance to prevent n+1 queries' do
+        before do
+          @map = FactoryBot.create(:map, published: true)
+          @layer = FactoryBot.create(:layer, map_id: @map.id, published: true)
+          # Create 6 places with relations between them
+          3.times do
+            place1 = FactoryBot.create(:place, :with_audio, layer_id: @layer.id, published: true)
+            place2 = FactoryBot.create(:place, layer_id: @layer.id, published: true)
+            FactoryBot.create(:relation, relation_from: place1, relation_to: place2)
+          end
+        end
+
+        def trigger
+          get :show, params: { id: @map.id, format: 'json' }, session: valid_session
+        end
+
+        it 'makes the same number of queries, no matter how many records are delivered' do
+          # Measure queries before adding additional records
+          x = count_queries { trigger }
+
+          # Create 10 additional layers and 2000 additional places with relations between them
+          10.times do
+            layer = FactoryBot.create(:layer, map_id: @map.id, published: true)
+            100.times do
+              place1 = FactoryBot.create(:place, :with_audio, layer_id: layer.id, published: true)
+              place2 = FactoryBot.create(:place, layer_id: layer.id, published: true)
+              FactoryBot.create(:relation, relation_from: place1, relation_to: place2)
+            end
+          end
+
+          # Measure queries after adding records
+          y = count_queries { trigger }
+
+          # Ensure query count remains the same
+          expect(x).to eq(y)
+        end
+      end
     end
 
     describe 'GET #allplaces' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -56,6 +56,7 @@ RSpec.configure do |config|
   config.include Devise::Test::ControllerHelpers, type: :helper
 
   config.include RequestSpecHelper, type: :request
+  config.include QueryCounter, type: :controller
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   # config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.include ActionCable::TestHelper

--- a/spec/support/query_counter.rb
+++ b/spec/support/query_counter.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module QueryCounter
   def count_queries(&block)
     query_count = 0
     ActiveSupport::Notifications.subscribed(
-      ->(_name, _start, _finish, _id, payload) {
-        query_count += 1 unless payload[:name].in?(['SCHEMA', 'TRANSACTION'])
+      lambda { |_name, _start, _finish, _id, payload|
+        query_count += 1 unless payload[:name].in?(%w[SCHEMA TRANSACTION])
       },
       'sql.active_record',
       &block

--- a/spec/support/query_counter.rb
+++ b/spec/support/query_counter.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
 module QueryCounter
-  def count_queries(&block)
+  def count_queries(&)
     query_count = 0
     ActiveSupport::Notifications.subscribed(
       lambda { |_name, _start, _finish, _id, payload|
         query_count += 1 unless payload[:name].in?(%w[SCHEMA TRANSACTION])
       },
       'sql.active_record',
-      &block
+      &
     )
     query_count
   end

--- a/spec/support/query_counter.rb
+++ b/spec/support/query_counter.rb
@@ -1,0 +1,13 @@
+module QueryCounter
+  def count_queries(&block)
+    query_count = 0
+    ActiveSupport::Notifications.subscribed(
+      ->(_name, _start, _finish, _id, payload) {
+        query_count += 1 unless payload[:name].in?(['SCHEMA', 'TRANSACTION'])
+      },
+      'sql.active_record',
+      &block
+    )
+    query_count
+  end
+end


### PR DESCRIPTION
With this PR, the performance of the public endpoints for maps#show and layers#show are refactored without implementing caching. By removing n+queries, the number of database queries could be reduced significantly. In order to prove the better performance, I added a test case for both requests which compares the amount of queries, executed once with a small amount of records and once with a bigger amount. So these test would fail if later on some n+1 queries would be added to these requests. 

To demonstrate the amount that the queries could be reduced, I played around a bit with the tests and executed them **against the current main branch**, which gave me this result, which shows how much the request count has been growing with the records - from 59 to 1859 within the layers controller and from 51 to 14081 within the maps controller while retrieving 10 layers with 200 places each: 
<img width="1682" alt="Bildschirmfoto 2025-02-26 um 10 02 45" src="https://github.com/user-attachments/assets/a108f98f-a350-459d-90ff-7d5eb176007c" />

In order to retrieve the actual amount of queries in the current refactored branch, I added an **(not committed) additional expectation** to show how much they could be actually reduced - layers are retrieved with 14 requests, and maps with only 6:
<img width="1678" alt="Bildschirmfoto 2025-02-25 um 15 20 02" src="https://github.com/user-attachments/assets/d419a291-0ce6-4767-b188-125aa4a10b4e" />


The last commit removes n+ one queries also for maps#allplaces and layers#show w/json, so these endpoints can also be used with optimized performance
