### PR TITLE
chore: use bundled rubocop version for linting

### DIFF
--- a/.github/workflows/rubyonrails-ci.yml
+++ b/.github/workflows/rubyonrails-ci.yml
@@ -27,17 +27,16 @@ jobs:
         with:
           bundler: default
           bundler-cache: true
-      - name: Install rubocop/brakeman
+      - name: Bundle install
         run: |
-          gem install rubocop
-          gem install brakeman
+          bundle install
       - name: Run security checks
         run: |
           bundle exec bundle audit --update
-          brakeman -q -w2
+          bundle exec brakeman -q -w2
       - name: Run linters
         run: |
-          rubocop --parallel
+          bundle exec rubocop --parallel
   run-rspec:
     name: RSpec
     needs: run-lint

--- a/spec/views/submission_configs/index.html.haml_spec.rb
+++ b/spec/views/submission_configs/index.html.haml_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'submission_configs/index', type: :view do
   it 'renders a list of submission_configs' do
     render
 
-    assert_select 'tr>td', text: 'Title Intro'.to_s, count: 2
+    assert_select 'tr>td', text: 'Title Intro', count: 2
     assert_select 'tr>td', text: 'Subtitle Intro', count: 2
     assert_select 'tr>td', text: 'MyIntro', count: 2
     assert_select 'tr>td', text: 'Title Outro', count: 2

--- a/spec/views/submission_configs/index.html.haml_spec.rb
+++ b/spec/views/submission_configs/index.html.haml_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'submission_configs/index', type: :view do
   it 'renders a list of submission_configs' do
     render
 
-    assert_select 'tr>td', text: 'Title Intro', count: 2
+    assert_select 'tr>td', text: 'Title Intro'.to_s, count: 2
     assert_select 'tr>td', text: 'Subtitle Intro', count: 2
     assert_select 'tr>td', text: 'MyIntro', count: 2
     assert_select 'tr>td', text: 'Title Outro', count: 2


### PR DESCRIPTION
This MR forces the CI to use the rubocop and brakeman versions that are defined in Gemfile.lock. In order to prove that another version is used,  I used 3 commits:

1) the first pipeline fails because I introduced a rubocop violation which is not appearing locally, but in the CI (this type of offence was for example detected in this pipeline: https://github.com/a-thousand-channels/ORTE-backend/actions/runs/13545941360/job/37857454759) 

2) the second pipeline changes the CI workflow to use the bundled version of rubocop and brakeman, hence there are no more offences

3) the third pipeline than removes the previously inserted offence, as we will soon update rubocop anyway.