### PR TITLE
fix: fix template error in public views caused by trying to sort images

### DIFF
--- a/app/views/public/layers/show.json.jbuilder
+++ b/app/views/public/layers/show.json.jbuilder
@@ -15,7 +15,7 @@ json.layer do
         json.extract! annotation, :id, :title, :text, :person_name, :audiolink
       end
       json.images do
-        json.array!(place.images.sort_by(&:sorting)) do |image|
+        json.array!(place.images.sort_by { |image| [image.sorting ? 0 : 1, image.sorting] }) do |image|
           json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url, :image_path, :image_filename, :image_on_disk)
         end
       end

--- a/app/views/public/maps/allplaces.json.jbuilder
+++ b/app/views/public/maps/allplaces.json.jbuilder
@@ -18,7 +18,7 @@ json.map do
         json.extract! annotation, :id, :title, :text, :person_name, :audiolink
       end
       json.images do
-        json.array! place.images.sort_by(&:sorting) do |image|
+        json.array!(place.images.sort_by { |image| [image.sorting ? 0 : 1, image.sorting] }) do |image|
           json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url)
         end
       end

--- a/app/views/public/maps/show.json.jbuilder
+++ b/app/views/public/maps/show.json.jbuilder
@@ -22,7 +22,7 @@ json.map do
             json.extract! annotation, :id, :title, :text, :person_name, :audiolink
           end
           json.images do
-            json.array! place.images.sort_by(&:sorting) do |image|
+            json.array!(place.images.sort_by { |image| [image.sorting ? 0 : 1, image.sorting] }) do |image|
               json.call(image, :id, :title, :source, :creator, :alt, :sorting, :image_linktag, :image_url)
             end
           end


### PR DESCRIPTION
As mentioned in https://github.com/a-thousand-channels/ORTE-backend/issues/370#issuecomment-2688878368, the refactored jbuilder views crash when trying to sort the images of a place by the sorting field. I could reproduce this error locally by setting the sorting value for some images  t an integer while leaving the remaining as nil. With the fix in this PR, the error is gone, even the values stay the same.

I will write a test for this, but as the image factory is broken, this might take a moment, so maybe this fix can already be merged and deployed to the staging server to proceed with testing.