### PR TITLE
test: add tests that cover the case which brought the new sorting logic in views to crash (#370)

### DIFF
--- a/spec/controllers/public/layers_controller_spec.rb
+++ b/spec/controllers/public/layers_controller_spec.rb
@@ -72,6 +72,16 @@ RSpec.describe Public::LayersController, type: :controller do
         expect(assigns(:places)).to eq([place2, place3, place1])
       end
 
+      it 'can handle images with and without sorting values' do
+        layer = FactoryBot.create(:layer, map_id: @map.id, published: true)
+        place = FactoryBot.create(:place, layer_id: layer.id, published: true)
+        FactoryBot.create(:image, place: place, sorting: nil)
+        FactoryBot.create(:image, place: place, sorting: 1)
+        get :show, params: { id: layer.to_param, map_id: @map.id, format: 'json' }, session: valid_session
+        expect(response.status).to eq 200
+        expect(response.content_type).to eq('application/json; charset=utf-8')
+      end
+
       it 'returns json for a published layer' do
         layer = Layer.create! valid_attributes
         get :show, params: { id: layer.to_param, map_id: @map.id, format: 'json' }, session: valid_session

--- a/spec/controllers/public/maps_controller_spec.rb
+++ b/spec/controllers/public/maps_controller_spec.rb
@@ -62,6 +62,17 @@ RSpec.describe Public::MapsController, type: :controller do
         expect(response).to have_http_status(403)
         expect(JSON.parse(response.body)['error']).to match(/Map not accessible/)
       end
+
+      it 'can handle images with and without sorting values' do
+        map = Map.create! valid_attributes
+        layer = FactoryBot.create(:layer, map_id: map.id, published: true)
+        place = FactoryBot.create(:place, layer_id: layer.id, published: true)
+        FactoryBot.create(:image, place: place, sorting: nil)
+        FactoryBot.create(:image, place: place, sorting: 1)
+        get :show, params: { id: map.friendly_id, format: 'json' }, session: valid_session
+        expect(response.status).to eq 200
+        expect(response.content_type).to eq('application/json; charset=utf-8')
+      end
     end
 
     describe 'GET #allplaces' do
@@ -98,6 +109,17 @@ RSpec.describe Public::MapsController, type: :controller do
         get :allplaces, params: { id: map.friendly_id, format: 'json' }, session: valid_session
         expect(response).to have_http_status(403)
         expect(JSON.parse(response.body)['error']).to match(/Map not accessible/)
+      end
+
+      it 'can handle images with and without sorting values' do
+        map = Map.create! valid_attributes
+        layer = FactoryBot.create(:layer, map_id: map.id, published: true)
+        place = FactoryBot.create(:place, layer_id: layer.id, published: true)
+        FactoryBot.create(:image, place: place, sorting: nil)
+        FactoryBot.create(:image, place: place, sorting: 1)
+        get :allplaces, params: { id: map.friendly_id, format: 'json' }, session: valid_session
+        expect(response.status).to eq 200
+        expect(response.content_type).to eq('application/json; charset=utf-8')
       end
     end
 


### PR DESCRIPTION
This PR adds test cases for the bug fixed in https://github.com/a-thousand-channels/ORTE-backend/pull/385. The three tests added here fail when executed against the code before the fix, and pass with the fixed code.

Here a screenshot of the failing test with the old code:
<img width="1229" alt="Bildschirmfoto 2025-02-28 um 13 35 56" src="https://github.com/user-attachments/assets/473d44b6-607b-47fa-adf0-142c893ec386" />
