### PR TITLE
test: use faker for randomised factories  #387

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,7 @@ group :development, :test do
   gem 'capybara-chromedriver-logger'
   gem 'database_cleaner'
   gem 'factory_bot_rails'
+  gem 'faker'
   gem 'json-schema'
   gem 'rails-controller-testing'
   gem 'rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -169,6 +169,8 @@ GEM
     factory_bot_rails (6.4.4)
       factory_bot (~> 6.5)
       railties (>= 5.0.0)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     foundation-icons-sass-rails (3.0.0)
@@ -539,6 +541,7 @@ DEPENDENCIES
   devise
   exception_notification
   factory_bot_rails
+  faker
   foundation-icons-sass-rails
   foundation-rails (= 6.6.2.0)
   friendly_id

--- a/spec/controllers/layers_controller_spec.rb
+++ b/spec/controllers/layers_controller_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe LayersController, type: :controller do
         get :show, params: { map_id: @map.friendly_id, id: layer.friendly_id }, session: valid_session
         expect(response).to have_http_status(200)
         expect(assigns(:layer)['use_background_from_parent_map']).to be_truthy
-        expect(assigns(:layer)['basemap_url']).to eq('MyMapBasemapUrl')
+        expect(assigns(:layer)['basemap_url']).to eq(@map.basemap_url)
       end
     end
 
@@ -271,7 +271,7 @@ RSpec.describe LayersController, type: :controller do
         get :edit, params: { map_id: @map.friendly_id, id: layer.friendly_id }, session: valid_session
         expect(response).to have_http_status(200)
         expect(assigns(:layer)['use_background_from_parent_map']).to be_truthy
-        expect(assigns(:layer)['basemap_url']).to eq('MyMapBasemapUrl')
+        expect(assigns(:layer)['basemap_url']).to eq(@map.basemap_url)
       end
     end
 
@@ -365,7 +365,7 @@ RSpec.describe LayersController, type: :controller do
           put :update, params: { map_id: @map.id, id: layer.id, layer: new_attributes }, session: valid_session
           layer.reload
           expect(layer.title).to eq('OtherTitle')
-          expect(layer.image_alt).to eq('An alternative text')
+          expect(layer.image_alt).to eq(new_attributes['image_alt'])
         end
 
         it 'redirects to the layer' do

--- a/spec/controllers/start_controller_spec.rb
+++ b/spec/controllers/start_controller_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe StartController, type: :controller do
   before(:all) do
     User.destroy_all
     @my_group = FactoryBot.create(:group)
-    @my_map1 = FactoryBot.create(:map, group_id: @my_group.id)
-    @my_map2 = FactoryBot.create(:map, group_id: @my_group.id)
+    @my_map1 = FactoryBot.create(:map, group_id: @my_group.id, title: 'Map A')
+    @my_map2 = FactoryBot.create(:map, group_id: @my_group.id, title: 'Map B')
     @user = FactoryBot.create(:user, group_id: @my_group.id)
   end
 

--- a/spec/factories/annotations.rb
+++ b/spec/factories/annotations.rb
@@ -2,11 +2,11 @@
 
 FactoryBot.define do
   factory :annotation do
-    title { 'MyString' }
-    text { 'MyText' }
-    published { '' }
-    sorting { 1 }
-    source { 'MyText' }
+    title { Faker::Mountain.name }
+    text { Faker::Commerce.department }
+    published { true }
+    sorting { Faker::Number.within(range: 1..20) }
+    source { Faker::Artist.name }
     place
     person
     trait :with_audio do

--- a/spec/factories/build_logs.rb
+++ b/spec/factories/build_logs.rb
@@ -4,9 +4,9 @@ FactoryBot.define do
   factory :build_log do
     map
     layer
-    output { 'MyString' }
-    size { 'MyString' }
-    version { 'MyString' }
+    output { Faker::Hacker.say_something_smart }
+    size { Faker::Hacker.adjective }
+    version { Faker::Hacker.noun }
     trait :changed do
       output { 'OtherString' }
     end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :group do
-    title { 'MyString' }
+    title { Faker::FunnyName.name }
     trait :invalid do
       title { nil }
     end

--- a/spec/factories/icons.rb
+++ b/spec/factories/icons.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :icon do
-    title { 'MyString' }
+    title { Faker::Lorem.word }
     iconset
     trait :invalid do
       iconset { nil }

--- a/spec/factories/iconsets.rb
+++ b/spec/factories/iconsets.rb
@@ -2,12 +2,12 @@
 
 FactoryBot.define do
   factory :iconset do
-    title { 'MyString' }
-    text { 'MyText' }
+    title { Faker::Artist.name }
+    text {  Faker::Lorem.sentence }
     icon_anchor { '[100,100]' }
     icon_size { '[50,50]' }
     popup_anchor { '[0,70]' }
-    class_name { 'diviconclass' }
+    class_name { Faker::Internet.slug }
     trait :invalid do
       title { nil }
     end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -2,14 +2,14 @@
 
 FactoryBot.define do
   factory :image do
-    title { 'Title' }
-    licence { 'Licence' }
-    source { 'Source' }
-    creator { 'Creator' }
+    title { Faker::Commerce.product_name }
+    licence { Faker::FunnyName.two_word_name }
+    source {  Faker::Lorem.word }
+    creator { Faker::FunnyName.name }
     place
-    alt { 'Alt' }
-    caption { 'Caption' }
-    sorting { 2 }
+    alt { Faker::Lorem.sentence }
+    caption { Faker::Hipster.sentence }
+    sorting { Faker::Number.between(from: 1, to: 10) }
     preview { false }
     itype { 'image' }
     trait :with_file do

--- a/spec/factories/layers.rb
+++ b/spec/factories/layers.rb
@@ -2,32 +2,17 @@
 
 FactoryBot.define do
   factory :layer do
-    title { 'MyString' }
-    subtitle { 'MyString' }
-    text { 'MyString' }
-    teaser { 'MyTeaser' }
-    credits { 'MyString' }
-    style { 'MyCSS' }
+    title { Faker::Book.genre }
+    subtitle { Faker::Team.name }
+    text { Faker::Hacker.say_something_smart }
+    teaser { Faker::Movie.quote }
+    credits { Faker::Team.mascot }
     published { false }
-    color { '#cc0000' }
+    color { Faker::Color.hex_color }
     use_background_from_parent_map { false }
-    basemap_url { 'MyLayerBasemapUrl' }
-    basemap_attribution { 'Basemap made by' }
-    background_color { '#454545' }
-    mapcenter_lat { '0.1' }
-    mapcenter_lon { '10' }
-    zoom { 12 }
-    tooltip_display_mode { 'false' }
-    places_sort_order { false }
-    rasterize_images { false }
-    submission_config { false }
-    exif_remove { true }
-    image_alt { 'An alternative text' }
-    image_licence { 'An image licence' }
-    image_source { 'The image source' }
-    image_creator { 'The creator of the image' }
-    image_caption { 'A caption for this image' }
     ltype { 'standard' }
+    image_alt { Faker::Quote.famous_last_words }
+    image_creator { Faker::Book.author }
     geojson { '{ "type": "FeatureCollection" }' }
     map
 

--- a/spec/factories/maps.rb
+++ b/spec/factories/maps.rb
@@ -2,23 +2,15 @@
 
 FactoryBot.define do
   factory :map do
-    title { 'MyString' }
-    subtitle { 'MyString' }
-    text { 'MyString' }
-    teaser { 'MyTeaser' }
-    credits { 'MyString' }
-    style { 'MyCSS' }
-    published { false }
-    basemap_url { 'MyMapBasemapUrl' }
-    basemap_attribution { 'Basemap made by' }
-    color { '#0000cc' }
-    background_color { '#151515' }
-    mapcenter_lat { '0.1' }
-    mapcenter_lon { '10' }
-    zoom { 12 }
-    popup_display_mode { 'click' }
-    tooltip_display_mode { 'false' }
-    places_sort_order { 'startdate' }
+    title { Faker::Book.title }
+    subtitle { Faker::Lorem.sentence }
+    text {  Faker::Lorem.paragraph }
+    credits { Faker::Book.author }
+    basemap_url { Faker::Internet.url(path: '/map.png') }
+    basemap_attribution { Faker::Lorem.sentence }
+    background_color { Faker::Color.hex_color }
+    mapcenter_lat { Faker::Address.latitude }
+    mapcenter_lon { Faker::Address.longitude }
     group
     trait :invalid do
       title { nil }

--- a/spec/factories/people.rb
+++ b/spec/factories/people.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :person do
-    name { 'MyString' }
-    info { 'MyText' }
+    name { Faker::FunnyName.name }
+    info { Faker::GreekPhilosophers.quote }
     map
     trait :invalid do
       name { nil }

--- a/spec/factories/places.rb
+++ b/spec/factories/places.rb
@@ -2,42 +2,42 @@
 
 FactoryBot.define do
   factory :place do
-    uid { 'UID1' }
-    title { 'MyTitle' }
-    subtitle { 'MySubTitle' }
-    teaser { 'MyText' }
-    text { 'MyText' }
-    sources { 'MyText' }
-    link { 'http://domain.com' }
-    startdate { '2018-04-27 19:48:51' }
-    enddate { '2019-04-27 19:48:51' }
-    lat { '0' }
-    lon { '0' }
-    direction { '320' }
-    location { 'Location' }
-    address { 'Address' }
-    zip { 'Zip' }
-    city { 'City' }
-    state { 'State' }
-    country { 'Country' }
+    uid { Faker::Internet.password(min_length: 3, max_length: 20, special_characters: true) }
+    title { Faker::TvShows::Simpsons.location }
+    subtitle { Faker::TvShows::Simpsons.quote }
+    teaser { Faker::Lorem.sentence }
+    text { Faker::Lorem.paragraph }
+    sources { Faker::Artist.name }
+    link { Faker::Internet.url }
+    startdate { Faker::Time.between(from: DateTime.now - 100.years, to: DateTime.now) }
+    enddate { Faker::Time.between(from: DateTime.now - 100.years, to: DateTime.now) }
+    lat { Faker::Address.latitude }
+    lon { Faker::Address.longitude }
+    direction { Faker::Alphanumeric.alphanumeric(number: 3) }
+    location { Faker::Games::Pokemon.location }
+    address { Faker::Address.street_address }
+    zip { Faker::Address.zip }
+    city { Faker::Address.city }
+    state { Faker::Address.state }
+    country { Faker::Address.country }
     published { false }
-    imagelink { 'Some link' }
+    imagelink { Faker::Internet.url(path: '/image.png') }
     layer
     trait :published do
       published { true }
     end
     trait :date_and_time do
-      startdate_date { '2018-04-30' }
+      startdate_date { Faker::Date.between(from: 100.years.ago, to: Date.today) }
       startdate_time { '11:45' }
-      enddate_date { '2022-05-30' }
+      enddate_date { Faker::Date.between(from: 100.years.ago, to: Date.today) }
       enddate_time { '16:45' }
     end
     trait :start_date_and_time do
-      startdate_date { '2018-04-30' }
+      startdate_date { Faker::Date.between(from: 100.years.ago, to: Date.today) }
       startdate_time { '11:45' }
     end
     trait :end_date_and_time do
-      enddate_date { '2022-05-30' }
+      enddate_date { Faker::Date.between(from: 100.years.ago, to: Date.today) }
       enddate_time { '16:45' }
     end
     trait :invalid do

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -2,8 +2,8 @@
 
 FactoryBot.define do
   factory :submission do
-    name { 'MyString' }
-    email { 'email@domain.org' }
+    name { Faker::FunnyName.name }
+    email { Faker::Internet.email }
     rights { true }
     privacy { true }
     locale { 'en' }

--- a/spec/factories/submission_configs.rb
+++ b/spec/factories/submission_configs.rb
@@ -2,13 +2,13 @@
 
 FactoryBot.define do
   factory :submission_config do
-    title_intro { 'MyString' }
-    subtitle_intro { 'MyString' }
-    intro { 'MyText' }
-    title_outro { 'MyString' }
-    outro { 'MyText' }
-    start_time { '2021-04-29 12:48:46' }
-    end_time { '2021-04-29 12:48:46' }
+    title_intro { Faker::Space.planet }
+    subtitle_intro { Faker::Space.galaxy }
+    intro { Faker::Lorem.sentence }
+    title_outro { Faker::Lorem.sentence }
+    outro { Faker::Lorem.sentence }
+    start_time { Faker::Time.between(from: DateTime.now - 100.years, to: DateTime.now) }
+    end_time { Faker::Time.between(from: DateTime.now - 100.years, to: DateTime.now) }
     use_city_only { false }
     trait :invalid do
       title_intro { nil }

--- a/spec/factories/videos.rb
+++ b/spec/factories/videos.rb
@@ -2,14 +2,14 @@
 
 FactoryBot.define do
   factory :video do
-    title { 'Title' }
-    licence { 'Licence' }
-    source { 'Source' }
-    creator { 'Creator' }
+    title { Faker::GreekPhilosophers.name }
+    licence { Faker::Hipster.word }
+    source { Faker::Book.publisher }
+    creator { Faker::Book.author }
     place
-    alt { 'Alt' }
-    caption { 'Caption' }
-    sorting { 2 }
+    alt { Faker::Commerce.material }
+    caption { Faker::Commerce.department }
+    sorting { Faker::Number.between(from: 1, to: 10) }
     preview { false }
     trait :with_file do
       after(:build) do |video|

--- a/spec/models/layer_spec.rb
+++ b/spec/models/layer_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe Layer, type: :model do
     it 'has some image metadata' do
       m = FactoryBot.create(:map)
       l = FactoryBot.create(:layer, map: m)
-      expect(l.image_alt).to eq('An alternative text')
-      expect(l.image_creator).to eq('The creator of the image')
+      expect(l.image_alt).to be_present
+      expect(l.image_creator).to be_present
     end
   end
 

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -249,14 +249,14 @@ RSpec.describe Place, type: :model do
     it 'is valid  ' do
       m = FactoryBot.create(:map)
       l = FactoryBot.create(:layer, map: m)
-      p1 = FactoryBot.create(:place, layer: l, address: 'An address1', location: 'A location', zip: '12345', city: 'City')
-      p2 = FactoryBot.create(:place, layer: l, address: 'An address2', location: 'A location', zip: '12345', city: 'City')
+      p1 = FactoryBot.create(:place, layer: l, address: 'An address1', location: 'A location', zip: '12345', city: 'City', country: 'Country')
+      p2 = FactoryBot.create(:place, layer: l, address: 'An address2', location: 'A location', zip: '12345', city: 'City', country: 'Country')
       a1 = FactoryBot.create(:annotation, place: p1, title: 'Annotation 1')
       a2 = FactoryBot.create(:annotation, place: p2, title: 'Annotation 2')
 
       other_map = FactoryBot.create(:map)
       other_layer = FactoryBot.create(:layer, map: other_map)
-      p3 = FactoryBot.create(:place, layer: other_layer, address: 'An address3', location: 'A location', zip: '12345', city: 'City')
+      p3 = FactoryBot.create(:place, layer: other_layer, address: 'An address3', location: 'A location', zip: '12345', city: 'City', country: 'Country')
       a3 = FactoryBot.create(:annotation, place: p3, title: 'Annotation 3')
       places = l.places
       csv_header = 'id,title,teaser,text,annotations,startdate,enddate,lat,lon,location,address,zip,city,country'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -66,6 +66,12 @@ RSpec.configure do |config|
   # instead of true.
   config.use_transactional_fixtures = false
 
+  config.before(:each, type: :view) do
+    allow(view).to receive(:render).and_wrap_original do |method, *args|
+      CGI.unescapeHTML(method.call(*args))
+    end
+  end
+
   config.before(:suite) do
     # only if compiled assets are really needed:
     # Rails.application.load_tasks

--- a/spec/views/images/show.html.haml_spec.rb
+++ b/spec/views/images/show.html.haml_spec.rb
@@ -12,13 +12,12 @@ RSpec.describe 'images/show', type: :view do
 
   it 'renders attributes in <p>' do
     render
-    expect(rendered).to match(/Title/)
-    expect(rendered).to match(/Licence/)
-    expect(rendered).to match(/Source/)
-    expect(rendered).to match(/Creator/)
-    expect(rendered).to match(//)
-    expect(rendered).to match(/Alt/)
-    expect(rendered).to match(/Caption/)
-    expect(rendered).to match(/2/)
+    expect(rendered).to match(@image.title)
+    expect(rendered).to match(@image.licence)
+    expect(rendered).to match(@image.source)
+    expect(rendered).to match(@image.creator)
+    expect(rendered).to match(@image.alt)
+    expect(rendered).to match(@image.caption)
+    expect(rendered).to match(@image.sorting.to_s)
   end
 end

--- a/spec/views/places/show.html.haml_spec.rb
+++ b/spec/views/places/show.html.haml_spec.rb
@@ -6,18 +6,18 @@ RSpec.describe 'places/show', type: :view do
   before(:each) do
     @map = FactoryBot.create(:map)
     @layer = FactoryBot.create(:layer, map_id: @map.id)
-    @place = FactoryBot.create(:place, layer_id: @layer.id)
+    @place = FactoryBot.create(:place, layer_id: @layer.id, published: false)
   end
 
   it 'renders attributes in <p>' do
     render
-    expect(rendered).to match(/MyTitle/)
-    expect(rendered).to match(/MyText/)
-    expect(rendered).to match(/MyText/)
-    expect(rendered).to match(/Location/)
-    expect(rendered).to match(/Address/)
-    expect(rendered).to match(/Zip/)
-    expect(rendered).to match(/City/)
+    expect(rendered).to match(@place.title)
+    expect(rendered).to match(@place.teaser)
+    expect(rendered).to match(@place.text)
+    expect(rendered).to match(@place.location)
+    expect(rendered).to match(@place.address)
+    expect(rendered).to match(@place.zip)
+    expect(rendered).to match(@place.city)
     expect(rendered).to match("<i class='fi-lock fi-18'></i>")
     expect(rendered).to match(//)
   end

--- a/spec/views/videos/show.html.haml_spec.rb
+++ b/spec/views/videos/show.html.haml_spec.rb
@@ -12,13 +12,12 @@ RSpec.describe 'videos/show', type: :view do
 
   it 'renders attributes in <p>' do
     render
-    expect(rendered).to match(/Title/)
-    expect(rendered).to match(/Licence/)
-    expect(rendered).to match(/Source/)
-    expect(rendered).to match(/Creator/)
-    expect(rendered).to match(//)
-    expect(rendered).to match(/Alt/)
-    expect(rendered).to match(/Caption/)
-    expect(rendered).to match(/2/)
+    expect(rendered).to match(@video.title)
+    expect(rendered).to match(@video.licence)
+    expect(rendered).to match(@video.source)
+    expect(rendered).to match(@video.creator)
+    expect(rendered).to match(@video.alt)
+    expect(rendered).to match(@video.caption)
+    expect(rendered).to match(@video.sorting.to_s)
   end
 end


### PR DESCRIPTION
Within this PR, the test suite is being improved by using the faker library to generate randomized values for the objects generated in the factories. This way, they behave more realistic in tests and are also more helpful when uses to generate data for local development (previously, all factory-generated objects would be titled "MyString").

Some tests had to be adjusted ad they were using harcdoded expectation matching the values defined in the factories. Now, it becomes clearer which values are really being tested.

I removed some values from the factories that are not used in any test, as it is best practice to only define values that are needed (there are probably still some more values which could be replaced or removed in the future, but now we have some good examples here on how to use faker).