### PR TITLE
chore: update rack gem because of vulnerability CVE-2025-27111

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -300,7 +300,7 @@ GEM
     puma (6.6.0)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.11)
+    rack (2.2.12)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-attack (6.7.0)


### PR DESCRIPTION
Security checks in pipeline require an  update of rack: https://github.com/a-thousand-channels/ORTE-backend/actions/runs/13695107960/job/38295672032